### PR TITLE
(SLV-34) Add method to run install task on target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+doc/
 pkg/
 Gemfile.lock
 Gemfile.local
@@ -5,6 +6,8 @@ vendor/
 spec/fixtures/
 log/
 junit/
+yardstick/
+.yardoc/
 .vagrant/
 .bundle/
 coverage/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,13 @@ Bundler/OrderedGems:
 #80 is just too small
 Metrics/LineLength:
   Max: 100
+
+Style/RedundantReturn:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+Metrics/MethodLength:
+  Max: 15

--- a/.yardstick.yml
+++ b/.yardstick.yml
@@ -1,0 +1,14 @@
+---
+threshold: 100
+rules:
+  ApiTag::Presence:
+    enabled: false
+  ApiTag::Inclusion:
+    enabled: false
+  ApiTag::ProtectedMethod:
+    enabled: false
+  ApiTag::PrivateMethod:
+    enabled: false
+  ExampleTag:
+    enabled: false
+    exclude: []

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ require "gem_of"
 eval(GemOf::Gems.new, binding) # rubocop:disable Security/Eval
 
 gemspec
-

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,8 @@ namespace :docs do
 
   desc "Measure YARD coverage"
   require "yardstick/rake/measurement"
-  Yardstick::Rake::Measurement.new(:measure) do |measurement|
+  options = YAML.load_file(".yardstick.yml")
+  Yardstick::Rake::Measurement.new(:measure, options) do |measurement|
     measurement.output = "yardstick/report.txt"
   end
 
@@ -124,7 +125,7 @@ namespace :test do
 
   desc "" # empty description so it doesn't show up in rake -T
   rototiller_task :check_spec do |t|
-    t.add_env(name: "SPEC_PATTERN", default: "spec/",
+    t.add_env(name: "SPEC_PATTERN", default: "**{,/*/**}/*_spec.rb",
               message: "The pattern RSpec will use to find tests")
   end
 end

--- a/lib/ref_arch_setup.rb
+++ b/lib/ref_arch_setup.rb
@@ -1,6 +1,8 @@
-# RefArchSetup
+# General namespace for RAS
 module RefArchSetup
-  %w[cli version].each do |lib|
+  %w[cli version install].each do |lib|
     require "ref_arch_setup/#{lib}"
   end
+  # location of modules shipped with RAS (Ref Arch Setup)
+  RAS_MODULE_PATH = File.dirname(__FILE__) + "/../modules"
 end

--- a/lib/ref_arch_setup/cli.rb
+++ b/lib/ref_arch_setup/cli.rb
@@ -1,12 +1,25 @@
 module RefArchSetup
   # CLI
   class CLI
+    # Initialize class
+    #
+    # @author Randell Pelak
+    #
+    # @param [Hash] options The options from the command line
+    # @option options [String] something not yet defined
+    #
+    # @return [void]
     def initialize(options)
       # if options['some_required_option'].nil? or options['some_required_option'].empty?
       #   raise "options some_required_option is required"
       # end
     end
 
+    # placeholder
+    # @example bogus placeholder
+    #   "void" #=> "void"
+    #
+    # @return [void]
     def doit
       puts "doing it all for my baby! (thanks Huey)"
     end

--- a/lib/ref_arch_setup/install.rb
+++ b/lib/ref_arch_setup/install.rb
@@ -1,0 +1,46 @@
+# General namespace for RAS
+module RefArchSetup
+  # Installation helper
+  #
+  # @author Randell Pelak
+  #
+  # @attr [string] target_master Host to install on
+  # @attr [string] pe_tarball_path Path to PE Tarball
+  class Install
+    # Initialize class
+    #
+    # @author Randell Pelak
+    #
+    # @param [string] target_master Host to install on
+    # @param [string] pe_tarball_path Path to pe tarball
+    #
+    # @return [void]
+    def initialize(target_master)
+      @target_master = target_master
+    end
+
+    # Runs the initial bootstrapping install
+    #
+    # @author Randell Pelak
+    #
+    # @param [string] pe_conf_path Path to pe.conf
+    # @param [string] pe_tarball_path Path to pe tarball
+    # @param [string] target_master Host to install on
+    #
+    # @return [true,false] Based on exit status of the bolt task
+    def bootstrap_mono(pe_conf_path, pe_tarball_path, target_master = @target_master)
+      env_vars = "PE_CONF_PATH=#{pe_conf_path};"
+      env_vars << "PE_TARBALL_PATH=#{pe_tarball_path};"
+      env_vars << "PE_TARGET_MASTER=#{target_master};"
+      command = env_vars.to_s + "bolt task run bogus::foo "
+      command << "--modulepath #{RAS_MODULE_PATH} --nodes #{target_master}"
+      puts "Running: #{command}"
+      output = `#{command}`
+      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
+      puts "ERROR: bolt command failed!" unless success
+      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
+      puts "Output was: #{output}"
+      return success
+    end
+  end
+end

--- a/lib/ref_arch_setup/version.rb
+++ b/lib/ref_arch_setup/version.rb
@@ -1,5 +1,7 @@
 module RefArchSetup
+  # Module for holding version info
   module Version
+    # Version number
     STRING = "0.0.1".freeze
   end
 end

--- a/ref_arch_setup.gemspec
+++ b/ref_arch_setup.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Run time dependencies
-  spec.add_runtime_dependency 'bolt', '~> 0.17'
+  spec.add_runtime_dependency "bolt", "~> 0.17"
 end

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+describe RefArchSetup::Install do
+  let(:target_master)   { "local://localhost" }
+  let(:pe_conf_path)    { "/tmp/pe.conf" }
+  let(:pe_tarball_path) { "/tmp/pe.tarball" }
+  let(:install)         { RefArchSetup::Install.new(target_master) }
+
+  describe "initialize" do
+    it "checks that the passed in parameters get used" do
+      temp_install = RefArchSetup::Install.new(target_master)
+      expect(temp_install.instance_variable_get("@target_master")).to eq(target_master)
+    end
+  end
+
+  describe "bootstrap_mono" do
+    before do
+      @expected_command = "PE_CONF_PATH=#{pe_conf_path};"
+      @expected_command << "PE_TARBALL_PATH=#{pe_tarball_path};"
+      @expected_command << "PE_TARGET_MASTER=#{target_master};"
+      @expected_command << "bolt task run bogus::foo --modulepath #{RefArchSetup::RAS_MODULE_PATH}"
+      @expected_command << " --nodes #{target_master}"
+    end
+
+    it "got a pass from bolt" do
+      expected_output = "All Good"
+      expected_status = 0
+      expect(install).to receive(:`).with(@expected_command).and_return(expected_output)
+      `(exit #{expected_status})`
+      expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+      expect(install).to receive(:puts).with("Running: #{@expected_command}")
+      expect(install).to receive(:puts).with("Exit status was: #{expected_status}")
+      expect(install).to receive(:puts).with("Output was: #{expected_output}")
+      expect(install.bootstrap_mono(pe_conf_path, pe_tarball_path, target_master)).to eq(true)
+    end
+
+    it "got a fail from bolt" do
+      expected_output = "No Good"
+      expected_status = 1
+      expect(install).to receive(:`).with(@expected_command).and_return(expected_output)
+      `(exit #{expected_status})`
+      expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
+      expect(install).to receive(:puts).with("Running: #{@expected_command}")
+      expect(install).to receive(:puts).with("ERROR: bolt command failed!")
+      expect(install).to receive(:puts).with("Exit status was: #{expected_status}")
+      expect(install).to receive(:puts).with("Output was: #{expected_output}")
+      expect(install.bootstrap_mono(pe_conf_path, pe_tarball_path, target_master)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Added a class called install, with a method called bootstrap_mono.
The method will call the bolt task that does the actual install on the target host.
It will need to be updated when we get the actual task.

Also cleaned up rubocop errors, and yardstick errors.