### PR TITLE
(SLV 129) Methods to move pe.conf and tarball

### DIFF
--- a/lib/ref_arch_setup.rb
+++ b/lib/ref_arch_setup.rb
@@ -5,4 +5,6 @@ module RefArchSetup
   end
   # location of modules shipped with RAS (Ref Arch Setup)
   RAS_MODULE_PATH = File.dirname(__FILE__) + "/../modules"
+  # location of fixtures shipped with RAS (Ref Arch Setup)
+  RAS_FIXTURES_PATH = File.dirname(__FILE__) + "/../fixtures"
 end

--- a/lib/ref_arch_setup.rb
+++ b/lib/ref_arch_setup.rb
@@ -1,6 +1,6 @@
 # General namespace for RAS
 module RefArchSetup
-  %w[cli version install].each do |lib|
+  %w[cli bolt_helper version install].each do |lib|
     require "ref_arch_setup/#{lib}"
   end
   # location of modules shipped with RAS (Ref Arch Setup)

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -4,7 +4,7 @@ module RefArchSetup
   module BoltHelper
     # Creates a dir on the target_host
     # Doesn't fail if dir is already there
-    # uses -p to create parent dirs is needed
+    # Uses -p to create parent dirs if needed
     #
     # @author Randell Pelak
     #

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -1,0 +1,63 @@
+# General namespace for RAS
+module RefArchSetup
+  # Bolt helper methods
+  module BoltHelper
+    # Creates a dir on the target_host
+    # Doesn't fail if dir is already there
+    # uses -p to create parent dirs is needed
+    #
+    # @author Randell Pelak
+    #
+    # @param [string] dir Directory to create
+    # @param [string] nodes Hosts to make dir on
+    #
+    # @return [true,false] Based on exit status of the bolt task
+    def self.make_dir(dir, nodes)
+      cmd = "[ -d #{dir} ] || mkdir -p #{dir}"
+      success = run_cmd_with_bolt(cmd, nodes)
+      puts "ERROR: Failed to make dir #{dir} on all nodes" unless success
+      return success
+    end
+
+    # Run a command with bolt on given nodes
+    #
+    # @author Randell Pelak
+    #
+    # @param [string] cmd Command to run on nodes
+    # @param [string] nodes Host to make dir on
+    #
+    # @return [true,false] Based on exit status of the bolt task
+    def self.run_cmd_with_bolt(cmd, nodes)
+      command = "bolt command run '#{cmd}'"
+      command << " --nodes #{nodes}"
+      puts "Running: #{command}"
+      output = `#{command}`
+      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
+      puts "ERROR: bolt command failed!" unless success
+      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
+      puts "Output was: #{output}"
+      return success
+    end
+
+    # Upload a file to given nodes
+    #
+    # @author Randell Pelak
+    #
+    # @param [string] source File to upload
+    # @param [string] destination Path to upload to
+    # @param [string] nodes Host to put files on
+    #
+    # @return [true,false] Based on exit status of the bolt task
+    def self.upload_file(source, destination, nodes)
+      command = "bolt file upload #{source} #{destination}"
+      command << " --nodes #{nodes}"
+      puts "Running: #{command}"
+      output = `#{command}`
+      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
+      puts "ERROR: bolt upload failed!" unless success
+      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
+      puts "Output was: #{output}"
+      return success
+    end
+  end
+end

--- a/lib/ref_arch_setup/install.rb
+++ b/lib/ref_arch_setup/install.rb
@@ -70,6 +70,7 @@ module RefArchSetup
                        dest_pe_conf_path = "#{TMP_WORK_DIR}/pe.conf", \
                        target_master = @target_master)
       success = BoltHelper.upload_file(src_pe_conf_path, dest_pe_conf_path, target_master)
+      puts "ERROR: Failed to upload pe.conf to target_master" unless success
       return success
     end
 
@@ -89,6 +90,7 @@ module RefArchSetup
         dest_pe_tarball_path += "/#{file_name}"
       end
       success = BoltHelper.upload_file(src_pe_tarball_path, dest_pe_tarball_path, target_master)
+      puts "ERROR: Failed to upload pe tarball to target_master" unless success
       return success
     end
   end

--- a/lib/ref_arch_setup/install.rb
+++ b/lib/ref_arch_setup/install.rb
@@ -1,5 +1,8 @@
 # General namespace for RAS
 module RefArchSetup
+  # A space to use as a default location to put files on target_host
+  TMP_WORK_DIR = "/tmp/ref_arch_setup".freeze
+
   # Installation helper
   #
   # @author Randell Pelak
@@ -38,6 +41,54 @@ module RefArchSetup
       puts "ERROR: bolt command failed!" unless success
       puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
       puts "Output was: #{output}"
+      return success
+    end
+
+    # Creates a tmp work dir for ref_arch_setup on the target_host
+    # Doesn't fail if the dir is already there.
+    #
+    # @author Randell Pelak
+    #
+    # @param [string] target_master Host to make the dir on
+    #
+    # @return [true,false] Based on exit status of the bolt task
+    def make_tmp_work_dir(target_master = @target_master)
+      success = BoltHelper.make_dir(TMP_WORK_DIR, target_master)
+      return success
+    end
+
+    # Upload the pe.conf to the target_host
+    #
+    # @author Randell Pelak
+    #
+    # @param [string] src_pe_conf_path Path to the source copy of the pe.conf file
+    # @param [string] dest_pe_conf_path Path to put the pe.conf at on the target host
+    # @param [string] target_master Host to upload to
+    #
+    # @return [true,false] Based on exit status of the bolt task
+    def upload_pe_conf(src_pe_conf_path = "#{RAS_FIXTURES_PATH}/pe.conf", \
+                       dest_pe_conf_path = "#{TMP_WORK_DIR}/pe.conf", \
+                       target_master = @target_master)
+      success = BoltHelper.upload_file(src_pe_conf_path, dest_pe_conf_path, target_master)
+      return success
+    end
+
+    # Upload the pe tarball to the target_host
+    #
+    # @author Randell Pelak
+    #
+    # @param [string] src_pe_tarball_path Path to the source copy of the tarball file
+    # @param [string] dest_pe_tarball_path Path to put the tarball at on the target host
+    # @param [string] target_master Host to upload to
+    #
+    # @return [true,false] Based on exit status of the bolt task
+    def upload_pe_tarball(src_pe_tarball_path, dest_pe_tarball_path = TMP_WORK_DIR, \
+                          target_master = @target_master)
+      if dest_pe_tarball_path == TMP_WORK_DIR
+        file_name = File.basename(src_pe_tarball_path)
+        dest_pe_tarball_path += "/#{file_name}"
+      end
+      success = BoltHelper.upload_file(src_pe_tarball_path, dest_pe_tarball_path, target_master)
       return success
     end
   end

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+describe RefArchSetup::BoltHelper do
+  let(:nodes)        { "local://localhost" }
+  let(:dir)          { "/tmp/ref_arch_setup" }
+  let(:cmd)          { "echo foo" }
+  let(:source)       { "/tmp/foo" }
+  let(:destination)  { "/tmp/bar" }
+
+  describe "make_dir" do
+    before do
+      @expected_command = "[ -d #{dir} ] ||"
+      @expected_command << " mkdir -p #{dir}"
+    end
+
+    it "got a pass from run_cmd_with_bolt" do
+      expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)\
+        .with(@expected_command, nodes).and_return(true)
+      expect(RefArchSetup::BoltHelper.make_dir(dir, nodes)).to eq(true)
+    end
+
+    it "got a fail from run_cmd_with_bolt" do
+      expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)\
+        .with(@expected_command, nodes).and_return(false)
+      expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        .with("ERROR: Failed to make dir #{dir} on all nodes")
+      expect(RefArchSetup::BoltHelper.make_dir(dir, nodes)).to eq(false)
+    end
+  end
+
+  describe "run_cmd_with_bolt" do
+    before do
+      @expected_command = "bolt command run '#{cmd}' --nodes #{nodes}"
+    end
+
+    it "got a pass from bolt" do
+      expected_output = "All Good"
+      expected_status = 0
+      expect(RefArchSetup::BoltHelper).to receive(:`)\
+        .with(@expected_command).and_return(expected_output)
+      `(exit #{expected_status})`
+      expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Exit status was: #{expected_status}")
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+      expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(true)
+    end
+
+    it "got a fail from bolt" do
+      expected_output = "No Good"
+      expected_status = 1
+      expect(RefArchSetup::BoltHelper).to receive(:`)\
+        .with(@expected_command).and_return(expected_output)
+      `(exit #{expected_status})`
+      expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("ERROR: bolt command failed!")
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Exit status was: #{expected_status}")
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+      expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(false)
+    end
+  end
+
+  describe "upload_file" do
+    before do
+      @expected_command = "bolt file upload #{source} #{destination} --nodes #{nodes}"
+    end
+
+    it "got a pass from bolt" do
+      expected_output = "All Good"
+      expected_status = 0
+      expect(RefArchSetup::BoltHelper).to receive(:`)\
+        .with(@expected_command).and_return(expected_output)
+      `(exit #{expected_status})`
+      expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Exit status was: #{expected_status}")
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+      expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes)).to eq(true)
+    end
+
+    it "got a fail from bolt" do
+      expected_output = "No Good"
+      expected_status = 1
+      expect(RefArchSetup::BoltHelper).to receive(:`)\
+        .with(@expected_command).and_return(expected_output)
+      `(exit #{expected_status})`
+      expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("ERROR: bolt upload failed!")
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Exit status was: #{expected_status}")
+      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+      expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes)).to eq(false)
+    end
+  end
+end

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -13,18 +13,22 @@ describe RefArchSetup::BoltHelper do
       @expected_command << " mkdir -p #{dir}"
     end
 
-    it "got a pass from run_cmd_with_bolt" do
-      expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)\
-        .with(@expected_command, nodes).and_return(true)
-      expect(RefArchSetup::BoltHelper.make_dir(dir, nodes)).to eq(true)
+    context "when run_cmd_with_bolt returns true" do
+      it "returns true" do
+        expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)\
+          .with(@expected_command, nodes).and_return(true)
+        expect(RefArchSetup::BoltHelper.make_dir(dir, nodes)).to eq(true)
+      end
     end
 
-    it "got a fail from run_cmd_with_bolt" do
-      expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)\
-        .with(@expected_command, nodes).and_return(false)
-      expect(RefArchSetup::BoltHelper).to receive(:puts)\
-        .with("ERROR: Failed to make dir #{dir} on all nodes")
-      expect(RefArchSetup::BoltHelper.make_dir(dir, nodes)).to eq(false)
+    context "when run_cmd_with_bolt returns false" do
+      it "returns false and output an error" do
+        expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)\
+          .with(@expected_command, nodes).and_return(false)
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("ERROR: Failed to make dir #{dir} on all nodes")
+        expect(RefArchSetup::BoltHelper.make_dir(dir, nodes)).to eq(false)
+      end
     end
   end
 
@@ -33,31 +37,37 @@ describe RefArchSetup::BoltHelper do
       @expected_command = "bolt command run '#{cmd}' --nodes #{nodes}"
     end
 
-    it "got a pass from bolt" do
-      expected_output = "All Good"
-      expected_status = 0
-      expect(RefArchSetup::BoltHelper).to receive(:`)\
-        .with(@expected_command).and_return(expected_output)
-      `(exit #{expected_status})`
-      expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Exit status was: #{expected_status}")
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-      expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(true)
+    context "when bolt works and returns true" do
+      it "returns true and outputs informative messages" do
+        expected_output = "All Good"
+        expected_status = 0
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(true)
+      end
     end
 
-    it "got a fail from bolt" do
-      expected_output = "No Good"
-      expected_status = 1
-      expect(RefArchSetup::BoltHelper).to receive(:`)\
-        .with(@expected_command).and_return(expected_output)
-      `(exit #{expected_status})`
-      expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("ERROR: bolt command failed!")
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Exit status was: #{expected_status}")
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-      expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(false)
+    context "when bolt fails and returns false" do
+      it "returns false and outputs informative messages and errors" do
+        expected_output = "No Good"
+        expected_status = 1
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("ERROR: bolt command failed!")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(false)
+      end
     end
   end
 
@@ -66,31 +76,37 @@ describe RefArchSetup::BoltHelper do
       @expected_command = "bolt file upload #{source} #{destination} --nodes #{nodes}"
     end
 
-    it "got a pass from bolt" do
-      expected_output = "All Good"
-      expected_status = 0
-      expect(RefArchSetup::BoltHelper).to receive(:`)\
-        .with(@expected_command).and_return(expected_output)
-      `(exit #{expected_status})`
-      expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Exit status was: #{expected_status}")
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-      expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes)).to eq(true)
+    context "when bolt works and returns true" do
+      it "returns true and outputs informative messages" do
+        expected_output = "All Good"
+        expected_status = 0
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes)).to eq(true)
+      end
     end
 
-    it "got a fail from bolt" do
-      expected_output = "No Good"
-      expected_status = 1
-      expect(RefArchSetup::BoltHelper).to receive(:`)\
-        .with(@expected_command).and_return(expected_output)
-      `(exit #{expected_status})`
-      expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("ERROR: bolt upload failed!")
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Exit status was: #{expected_status}")
-      expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-      expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes)).to eq(false)
+    context "when bolt fails and returns false" do
+      it "returns false and outputs informative messages and errors" do
+        expected_output = "No Good"
+        expected_status = 1
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("ERROR: bolt upload failed!")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes)).to eq(false)
+      end
     end
   end
 end

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -49,74 +49,96 @@ describe RefArchSetup::Install do
   end
 
   describe "make_tmp_work_dir" do
-    it "with defaults and got a pass from bolt_helper" do
-      expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
-        .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(true)
-      expect(install.make_tmp_work_dir).to eq(true)
+    context "with defaults and make_dir returns true" do
+      it "returns true" do
+        expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
+          .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(true)
+        expect(install.make_tmp_work_dir).to eq(true)
+      end
     end
 
-    it "got a pass from bolt_helper" do
-      expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
-        .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(true)
-      expect(install.make_tmp_work_dir(target_master)).to eq(true)
+    context "with option values passed in and make_dir returns true" do
+      it "returns true" do
+        expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
+          .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(true)
+        expect(install.make_tmp_work_dir(target_master)).to eq(true)
+      end
     end
 
-    it "got a fail from bolt_helper" do
-      expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
-        .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(false)
-      expect(install.make_tmp_work_dir(target_master)).to eq(false)
+    context "with option values passed in and make_dir returns false" do
+      it "returns false" do
+        expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
+          .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(false)
+        expect(install.make_tmp_work_dir(target_master)).to eq(false)
+      end
     end
   end
 
   describe "upload_pe_conf" do
-    it "with defaults and got a pass from bolt_helper" do
-      src = "#{RefArchSetup::RAS_FIXTURES_PATH}/pe.conf"
-      dest = "#{RefArchSetup::TMP_WORK_DIR}/pe.conf"
-      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
-        .with(src, dest, target_master).and_return(true)
-      expect(install.upload_pe_conf).to eq(true)
+    context "with defaults and upload_file returns true" do
+      it "returns true" do
+        src = "#{RefArchSetup::RAS_FIXTURES_PATH}/pe.conf"
+        dest = "#{RefArchSetup::TMP_WORK_DIR}/pe.conf"
+        expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+          .with(src, dest, target_master).and_return(true)
+        expect(install.upload_pe_conf).to eq(true)
+      end
     end
 
-    it "got a pass from bolt_helper" do
-      src = pe_conf_path
-      dest = "/tmp/foo"
-      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
-        .with(src, dest, target_master).and_return(true)
-      expect(install.upload_pe_conf(src, dest, target_master)).to eq(true)
+    context "with option values passed in and upload_file returns true" do
+      it "returns true" do
+        src = pe_conf_path
+        dest = "/tmp/foo"
+        expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+          .with(src, dest, target_master).and_return(true)
+        expect(install.upload_pe_conf(src, dest, target_master)).to eq(true)
+      end
     end
 
-    it "got a fail from bolt_helper" do
-      src = pe_conf_path
-      dest = "/tmp/foo"
-      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
-        .with(src, dest, target_master).and_return(false)
-      expect(install.upload_pe_conf(src, dest, target_master)).to eq(false)
+    context "with option values passed in and upload_file returns false" do
+      it "returns false" do
+        src = pe_conf_path
+        dest = "/tmp/foo"
+        expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+          .with(src, dest, target_master).and_return(false)
+        expect(install).to receive(:puts)\
+          .with("ERROR: Failed to upload pe.conf to target_master")
+        expect(install.upload_pe_conf(src, dest, target_master)).to eq(false)
+      end
     end
   end
 
   describe "upload_pe_tarball" do
-    it "with defaults and got a pass from bolt_helper" do
-      src = "/tmp/foo.tar"
-      dest = "#{RefArchSetup::TMP_WORK_DIR}/foo.tar"
-      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
-        .with(src, dest, target_master).and_return(true)
-      expect(install.upload_pe_tarball(src)).to eq(true)
+    context "with defaults and upload_file returns true" do
+      it "returns true" do
+        src = "/tmp/foo.tar"
+        dest = "#{RefArchSetup::TMP_WORK_DIR}/foo.tar"
+        expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+          .with(src, dest, target_master).and_return(true)
+        expect(install.upload_pe_tarball(src)).to eq(true)
+      end
     end
 
-    it "got a pass from bolt_helper" do
-      src = "/tmp/foo.tar"
-      dest = "/tmp/foo"
-      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
-        .with(src, dest, target_master).and_return(true)
-      expect(install.upload_pe_tarball(src, dest, target_master)).to eq(true)
+    context "with option values passed in and upload_file returns true" do
+      it "returns true" do
+        src = "/tmp/foo.tar"
+        dest = "/tmp/foo"
+        expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+          .with(src, dest, target_master).and_return(true)
+        expect(install.upload_pe_tarball(src, dest, target_master)).to eq(true)
+      end
     end
 
-    it "got a fail from bolt_helper" do
-      src = "/tmp/foo.tar"
-      dest = "/tmp/foo"
-      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
-        .with(src, dest, target_master).and_return(false)
-      expect(install.upload_pe_tarball(src, dest, target_master)).to eq(false)
+    context "with option values passed in and upload_file returns false" do
+      it "returns false" do
+        src = "/tmp/foo.tar"
+        dest = "/tmp/foo"
+        expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+          .with(src, dest, target_master).and_return(false)
+        expect(install).to receive(:puts)\
+          .with("ERROR: Failed to upload pe tarball to target_master")
+        expect(install.upload_pe_tarball(src, dest, target_master)).to eq(false)
+      end
     end
   end
 end

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -47,4 +47,76 @@ describe RefArchSetup::Install do
       expect(install.bootstrap_mono(pe_conf_path, pe_tarball_path, target_master)).to eq(false)
     end
   end
+
+  describe "make_tmp_work_dir" do
+    it "with defaults and got a pass from bolt_helper" do
+      expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
+        .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(true)
+      expect(install.make_tmp_work_dir).to eq(true)
+    end
+
+    it "got a pass from bolt_helper" do
+      expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
+        .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(true)
+      expect(install.make_tmp_work_dir(target_master)).to eq(true)
+    end
+
+    it "got a fail from bolt_helper" do
+      expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
+        .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(false)
+      expect(install.make_tmp_work_dir(target_master)).to eq(false)
+    end
+  end
+
+  describe "upload_pe_conf" do
+    it "with defaults and got a pass from bolt_helper" do
+      src = "#{RefArchSetup::RAS_FIXTURES_PATH}/pe.conf"
+      dest = "#{RefArchSetup::TMP_WORK_DIR}/pe.conf"
+      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+        .with(src, dest, target_master).and_return(true)
+      expect(install.upload_pe_conf).to eq(true)
+    end
+
+    it "got a pass from bolt_helper" do
+      src = pe_conf_path
+      dest = "/tmp/foo"
+      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+        .with(src, dest, target_master).and_return(true)
+      expect(install.upload_pe_conf(src, dest, target_master)).to eq(true)
+    end
+
+    it "got a fail from bolt_helper" do
+      src = pe_conf_path
+      dest = "/tmp/foo"
+      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+        .with(src, dest, target_master).and_return(false)
+      expect(install.upload_pe_conf(src, dest, target_master)).to eq(false)
+    end
+  end
+
+  describe "upload_pe_tarball" do
+    it "with defaults and got a pass from bolt_helper" do
+      src = "/tmp/foo.tar"
+      dest = "#{RefArchSetup::TMP_WORK_DIR}/foo.tar"
+      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+        .with(src, dest, target_master).and_return(true)
+      expect(install.upload_pe_tarball(src)).to eq(true)
+    end
+
+    it "got a pass from bolt_helper" do
+      src = "/tmp/foo.tar"
+      dest = "/tmp/foo"
+      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+        .with(src, dest, target_master).and_return(true)
+      expect(install.upload_pe_tarball(src, dest, target_master)).to eq(true)
+    end
+
+    it "got a fail from bolt_helper" do
+      src = "/tmp/foo.tar"
+      dest = "/tmp/foo"
+      expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
+        .with(src, dest, target_master).and_return(false)
+      expect(install.upload_pe_tarball(src, dest, target_master)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION

created a bolt helper module to wrap around bolt commands and upload requests.
Created methods in install to move pe.conf and PE tarball to a selected host.