### PR TITLE
(SLV-127)

### DIFF
--- a/lib/ref_arch_setup.rb
+++ b/lib/ref_arch_setup.rb
@@ -1,6 +1,6 @@
 # General namespace for RAS
 module RefArchSetup
-  %w[cli bolt_helper version install url_helper].each do |lib|
+  %w[cli bolt_helper version install].each do |lib|
     require "ref_arch_setup/#{lib}"
   end
   # location of modules shipped with RAS (Ref Arch Setup)

--- a/lib/ref_arch_setup.rb
+++ b/lib/ref_arch_setup.rb
@@ -1,6 +1,6 @@
 # General namespace for RAS
 module RefArchSetup
-  %w[cli bolt_helper version install].each do |lib|
+  %w[cli bolt_helper version install url_helper].each do |lib|
     require "ref_arch_setup/#{lib}"
   end
   # location of modules shipped with RAS (Ref Arch Setup)

--- a/lib/ref_arch_setup/url_helper.rb
+++ b/lib/ref_arch_setup/url_helper.rb
@@ -1,12 +1,28 @@
 # General namespace for RAS
 module RefArchSetup
-
+  # Code to illustrate a Beaker-based method of deriving a tarball URL
   class UrlHelper
-
-    def get_url(pe_dir, pe_ver, host)
-      "#{pe_dir}/puppet-enterprise-#{pe_ver}-#{host}.tar.gz"
+    # Extracted from pe_utils.prepare_hosts
+    #   this version leaves filename = "#{host['dist']}" to show how it was originally used
+    def prepare_ras_host(host)
+      # host['dist'] is used for the filename
+      host["dist"] = "puppet-enterprise-#{host['pe_ver']}-#{host['platform']}"
     end
 
-  end
+    # Extracted from pe_utils.fetch_pe_on_unix
+    #   this assumes being called by beaker with a host (master)
+    def get_ras_pe_url(host)
+      prepare_ras_host(host)
+      path = host["pe_dir"]
+      filename = host["dist"]
+      extension = ".tar.gz"
+      url = "#{path}/#{filename}#{extension}"
 
+      unless link_exists?(url)
+        raise "attempting to construct download URL for #{host}, #{url} does not exist"
+      end
+
+      return url
+    end
+  end
 end

--- a/lib/ref_arch_setup/url_helper.rb
+++ b/lib/ref_arch_setup/url_helper.rb
@@ -1,0 +1,12 @@
+# General namespace for RAS
+module RefArchSetup
+
+  class UrlHelper
+
+    def get_url(pe_dir, pe_ver, host)
+      "#{pe_dir}/puppet-enterprise-#{pe_ver}-#{host}.tar.gz"
+    end
+
+  end
+
+end

--- a/lib/ref_arch_setup/url_helper.rb
+++ b/lib/ref_arch_setup/url_helper.rb
@@ -2,16 +2,53 @@
 module RefArchSetup
   # Code to illustrate a Beaker-based method of deriving a tarball URL
   class UrlHelper
+    # Determine is a given URL is accessible
+    # *** copied from Beaker to illustrate the example ***
+    #
+    # @param [String] link The URL to examine
+    # @return [Boolean] true if the URL has a '200' HTTP response code, false otherwise
+    # @example
+    #  extension = link_exists?("#{URL}.tar.gz") ? ".tar.gz" : ".tar"
+    #
+    def link_exists?(link)
+      require "net/http"
+      require "net/https"
+      require "open-uri"
+      url = URI.parse(link)
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = (url.scheme == 'https')
+      http.verify_mode = (OpenSSL::SSL::VERIFY_NONE)
+      http.start do |http|
+        return http.head(url.request_uri).code == "200"
+      end
+    end
+
+    # Prepares the host by setting the host["dist"]
+    #
     # Extracted from pe_utils.prepare_hosts
     #   this version leaves filename = "#{host['dist']}" to show how it was originally used
+    #
+    # @param [Host] host The unix style host where PE will be installed
+    # @return [String] the host["dist"] aka PE filename
+    # @example
+    #   prepare_ras_host(host)
+    #
     def prepare_ras_host(host)
       # host['dist'] is used for the filename
-      host["dist"] = "puppet-enterprise-#{host['pe_ver']}-#{host['platform']}"
+      host["dist"] = "puppet-enterprise-#{host["pe_ver"]}-#{host["platform"]}"
     end
 
     # Extracted from pe_utils.fetch_pe_on_unix
-    #   this assumes being called by beaker with a host (master)
-    def get_ras_pe_url(host)
+    #   assumes being called by beaker with a host (master)
+    #   this version calls prepare_ras_host which sets host["dist"];
+    #   similar to beaker implementation
+    #
+    # @param [Host] host The unix style host where PE will be installed
+    # @return [String] the tarball URL
+    # @example
+    #   url = get_ras_pe_tarball_url(host)
+    #
+    def get_ras_pe_tarball_url(host)
       prepare_ras_host(host)
       path = host["pe_dir"]
       filename = host["dist"]
@@ -24,5 +61,28 @@ module RefArchSetup
 
       return url
     end
+
+    # Extracted from pe_utils.fetch_pe_on_unix
+    #   assumes being called by beaker with a host (master)
+    #   this version is simplified by removing the call to prepare_ras_host
+    #
+    # @param [Host] host The unix style host where PE will be installed
+    # @return [String] the tarball URL
+    # @example
+    #   url = get_ras_pe_tarball_url(host)
+    #
+    def get_ras_pe_tarball_url_simple(host)
+      path = host["pe_dir"]
+      filename = "puppet-enterprise-#{host["pe_ver"]}-#{host["platform"]}"
+      extension = ".tar.gz"
+      url = "#{path}/#{filename}#{extension}"
+
+      unless link_exists?(url)
+        raise "attempting to construct download URL for #{host}, #{url} does not exist"
+      end
+
+      return url
+    end
+
   end
 end

--- a/lib/ref_arch_setup/url_helper.rb
+++ b/lib/ref_arch_setup/url_helper.rb
@@ -11,12 +11,12 @@ module RefArchSetup
     # Determine if a given URL is accessible
     # *** added as a stub for the version in Beaker WebHelpers ***
     #
-    # @param [String] link The URL to examine
+    # @param [String] _link The URL to examine
     # @return [Boolean] true
     # @example
     #  link_exists?(url)
     #
-    def link_exists?(link)
+    def link_exists?(_link)
       true
     end
 
@@ -31,7 +31,7 @@ module RefArchSetup
     #
     def prepare_ras_host(host)
       # host['dist'] is used for the filename
-      host["dist"] = "puppet-enterprise-#{host["pe_ver"]}-#{host["platform"]}"
+      host["dist"] = "puppet-enterprise-#{host['pe_ver']}-#{host['platform']}"
     end
 
     # Builds a PE tarball URL for the specified host using prepare_ras_host
@@ -93,6 +93,5 @@ module RefArchSetup
 
       return url
     end
-
   end
 end

--- a/spec/ref_arch_setup/url_helper_spec.rb
+++ b/spec/ref_arch_setup/url_helper_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require_relative "../../lib/ref_arch_setup/url_helper.rb"
 
 describe RefArchSetup::UrlHelper do
 
@@ -6,17 +7,44 @@ describe RefArchSetup::UrlHelper do
 
   TEST_PE_DIR = "http://enterprise.delivery.puppetlabs.net/archives/internal/2018.1".freeze
   TEST_PE_VER = "2018.1.0-rc14".freeze
-  TEST_HOST = "el-6-x86_64".freeze
+  TEST_PLATFORM = "el-6-x86_64".freeze
+  TEST_DIST = "puppet-enterprise-2018.1.0-rc14-el-6-x86_64".freeze
   TEST_EXPECTED_URL = "http://enterprise.delivery.puppetlabs.net/archives/internal/2018.1/puppet-enterprise-2018.1.0-rc14-el-6-x86_64.tar.gz"
 
-  describe "#get_url" do
+  let!(:host) {{"pe_dir" => TEST_PE_DIR, "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM}}
 
-    context "when given a pe_dir, pe_ver, and host" do
+  describe "#prepare_ras_host" do
+
+    context "when given a host with a pe_dir, pe_ver, and platform" do
+
+      it "it sets and returns the filename as host['dist']" do
+        expect(host["dist"]).to eq(nil)
+        expect(url_helper.prepare_ras_host(host)).to eq(TEST_DIST)
+        expect(host["dist"]).to eq(TEST_DIST)
+      end
+
+    end
+
+  end
+
+  describe "#get_ras_pe_tarball_url" do
+
+    context "when given a host with a pe_dir, pe_ver, and platform" do
 
       it "it returns the download URL" do
+        expect(url_helper.get_ras_pe_tarball_url(host)).to eq(TEST_EXPECTED_URL)
+      end
 
-        expect(url_helper.get_url(TEST_PE_DIR, TEST_PE_VER, TEST_HOST)).to eq(TEST_EXPECTED_URL)
+    end
 
+  end
+
+  describe "#get_ras_pe_tarball_url_simple" do
+
+    context "when given a host with a pe_dir, pe_ver, and platform" do
+
+      it "it returns the download URL" do
+        expect(url_helper.get_ras_pe_tarball_url_simple(host)).to eq(TEST_EXPECTED_URL)
       end
 
     end

--- a/spec/ref_arch_setup/url_helper_spec.rb
+++ b/spec/ref_arch_setup/url_helper_spec.rb
@@ -9,9 +9,21 @@ describe RefArchSetup::UrlHelper do
   TEST_PE_VER = "2018.1.0-rc14".freeze
   TEST_PLATFORM = "el-6-x86_64".freeze
   TEST_DIST = "puppet-enterprise-2018.1.0-rc14-el-6-x86_64".freeze
-  TEST_EXPECTED_URL = "http://enterprise.delivery.puppetlabs.net/archives/internal/2018.1/puppet-enterprise-2018.1.0-rc14-el-6-x86_64.tar.gz"
+  TEST_VALID_URL = "http://enterprise.delivery.puppetlabs.net/archives/internal/2018.1/puppet-enterprise-2018.1.0-rc14-el-6-x86_64.tar.gz"
 
   let!(:host) {{"pe_dir" => TEST_PE_DIR, "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM}}
+
+  describe "#link_exists?" do
+
+    context "when called as part of the example" do
+
+      it "it returns true" do
+        expect(url_helper.link_exists?(TEST_VALID_URL)).to eq(true)
+      end
+
+    end
+
+  end
 
   describe "#prepare_ras_host" do
 
@@ -27,24 +39,92 @@ describe RefArchSetup::UrlHelper do
 
   end
 
-  describe "#get_ras_pe_tarball_url" do
+  describe "#get_ras_pe_tarball_url_with_prepare" do
 
     context "when given a host with a pe_dir, pe_ver, and platform" do
 
-      it "it returns the download URL" do
-        expect(url_helper.get_ras_pe_tarball_url(host)).to eq(TEST_EXPECTED_URL)
+      context "when the link exists" do
+
+        it "it returns the download URL" do
+          expect(url_helper).to receive(:link_exists?).with(TEST_VALID_URL).and_return(true)
+          expect(url_helper.get_ras_pe_tarball_url_with_prepare(host)).to eq(TEST_VALID_URL)
+        end
+
       end
+
+      context "when the link does not exist" do
+
+        let!(:invalid_host) {{"pe_dir" => "xyz", "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM}}
+        invalid_url = "xyz/#{TEST_DIST}.tar.gz"
+
+        it "it raises an error" do
+          expect(url_helper).to receive(:link_exists?).with(invalid_url).and_return(false)
+          expect{url_helper.get_ras_pe_tarball_url_with_prepare(invalid_host)}.to raise_error(RuntimeError)
+        end
+
+      end
+
 
     end
 
   end
 
-  describe "#get_ras_pe_tarball_url_simple" do
+  describe "#get_ras_pe_tarball_url" do
 
     context "when given a host with a pe_dir, pe_ver, and platform" do
 
-      it "it returns the download URL" do
-        expect(url_helper.get_ras_pe_tarball_url_simple(host)).to eq(TEST_EXPECTED_URL)
+      context "when the link exists" do
+
+        it "it returns the download URL" do
+          expect(url_helper).to receive(:link_exists?).with(TEST_VALID_URL).and_return(true)
+          expect(url_helper.get_ras_pe_tarball_url(host)).to eq(TEST_VALID_URL)
+        end
+
+      end
+
+      context "when the link does not exist" do
+
+        let!(:invalid_host) {{"pe_dir" => "xyz", "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM}}
+        invalid_url = "xyz/#{TEST_DIST}.tar.gz"
+
+        it "it raises an error" do
+          expect(url_helper).to receive(:link_exists?).with(invalid_url).and_return(false)
+          expect{url_helper.get_ras_pe_tarball_url(invalid_host)}.to raise_error(RuntimeError)
+        end
+
+      end
+
+    end
+
+    context "when given a host without a pe_dir" do
+
+      let!(:invalid_host) {{"pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM}}
+
+      it "it raises an error" do
+        expect(url_helper).not_to receive(:link_exists?)
+        expect{url_helper.get_ras_pe_tarball_url(invalid_host)}.to raise_error(RuntimeError)
+      end
+
+    end
+
+    context "when given a host without a pe_ver" do
+
+      let!(:invalid_host) {{"pe_dir" => TEST_PE_DIR, "platform" => TEST_PLATFORM}}
+
+      it "it raises an error" do
+        expect(url_helper).not_to receive(:link_exists?)
+        expect{url_helper.get_ras_pe_tarball_url(invalid_host)}.to raise_error(RuntimeError)
+      end
+
+    end
+
+    context "when given a host without a platform" do
+
+      let!(:invalid_host) {{"pe_dir" => TEST_PE_DIR, "pe_ver" => TEST_PE_VER}}
+
+      it "it raises an error" do
+        expect(url_helper).not_to receive(:link_exists?)
+        expect{url_helper.get_ras_pe_tarball_url(invalid_host)}.to raise_error(RuntimeError)
       end
 
     end

--- a/spec/ref_arch_setup/url_helper_spec.rb
+++ b/spec/ref_arch_setup/url_helper_spec.rb
@@ -2,133 +2,106 @@ require "spec_helper"
 require_relative "../../lib/ref_arch_setup/url_helper.rb"
 
 describe RefArchSetup::UrlHelper do
-
-  let(:url_helper) { RefArchSetup::UrlHelper.new() }
+  let(:url_helper) { RefArchSetup::UrlHelper.new }
 
   TEST_PE_DIR = "http://enterprise.delivery.puppetlabs.net/archives/internal/2018.1".freeze
   TEST_PE_VER = "2018.1.0-rc14".freeze
   TEST_PLATFORM = "el-6-x86_64".freeze
   TEST_DIST = "puppet-enterprise-2018.1.0-rc14-el-6-x86_64".freeze
-  TEST_VALID_URL = "http://enterprise.delivery.puppetlabs.net/archives/internal/2018.1/puppet-enterprise-2018.1.0-rc14-el-6-x86_64.tar.gz"
+  TEST_URL = "http://test.net/2018.1/puppet-enterprise-2018.1.0-rc14-el-6-x86_64.tar.gz".freeze
 
-  let!(:host) {{"pe_dir" => TEST_PE_DIR, "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM}}
+  let!(:host) { { "pe_dir" => TEST_PE_DIR, "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM } }
 
   describe "#link_exists?" do
-
     context "when called as part of the example" do
-
       it "it returns true" do
-        expect(url_helper.link_exists?(TEST_VALID_URL)).to eq(true)
+        expect(url_helper.link_exists?(TEST_URL)).to eq(true)
       end
-
     end
-
   end
 
   describe "#prepare_ras_host" do
-
     context "when given a host with a pe_dir, pe_ver, and platform" do
-
       it "it sets and returns the filename as host['dist']" do
         expect(host["dist"]).to eq(nil)
         expect(url_helper.prepare_ras_host(host)).to eq(TEST_DIST)
         expect(host["dist"]).to eq(TEST_DIST)
       end
-
     end
-
   end
 
   describe "#get_ras_pe_tarball_url_with_prepare" do
-
     context "when given a host with a pe_dir, pe_ver, and platform" do
-
       context "when the link exists" do
-
         it "it returns the download URL" do
-          expect(url_helper).to receive(:link_exists?).with(TEST_VALID_URL).and_return(true)
-          expect(url_helper.get_ras_pe_tarball_url_with_prepare(host)).to eq(TEST_VALID_URL)
+          expect(url_helper).to receive(:link_exists?).with(TEST_URL).and_return(true)
+          expect(url_helper.get_ras_pe_tarball_url_with_prepare(host)).to eq(TEST_URL)
         end
-
       end
 
       context "when the link does not exist" do
-
-        let!(:invalid_host) {{"pe_dir" => "xyz", "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM}}
+        let!(:invalid_host) do
+          { "pe_dir" => "xyz", "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM }
+        end
         invalid_url = "xyz/#{TEST_DIST}.tar.gz"
 
         it "it raises an error" do
           expect(url_helper).to receive(:link_exists?).with(invalid_url).and_return(false)
-          expect{url_helper.get_ras_pe_tarball_url_with_prepare(invalid_host)}.to raise_error(RuntimeError)
+          expect do
+            url_helper.get_ras_pe_tarball_url_with_prepare(invalid_host)
+          end.to raise_error(RuntimeError)
         end
-
       end
-
-
     end
-
   end
 
   describe "#get_ras_pe_tarball_url" do
-
     context "when given a host with a pe_dir, pe_ver, and platform" do
-
       context "when the link exists" do
-
         it "it returns the download URL" do
-          expect(url_helper).to receive(:link_exists?).with(TEST_VALID_URL).and_return(true)
-          expect(url_helper.get_ras_pe_tarball_url(host)).to eq(TEST_VALID_URL)
+          expect(url_helper).to receive(:link_exists?).with(TEST_URL).and_return(true)
+          expect(url_helper.get_ras_pe_tarball_url(host)).to eq(TEST_URL)
         end
-
       end
 
       context "when the link does not exist" do
-
-        let!(:invalid_host) {{"pe_dir" => "xyz", "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM}}
+        let!(:invalid_host) do
+          { "pe_dir" => "xyz", "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM }
+        end
         invalid_url = "xyz/#{TEST_DIST}.tar.gz"
 
         it "it raises an error" do
           expect(url_helper).to receive(:link_exists?).with(invalid_url).and_return(false)
-          expect{url_helper.get_ras_pe_tarball_url(invalid_host)}.to raise_error(RuntimeError)
+          expect { url_helper.get_ras_pe_tarball_url(invalid_host) }.to raise_error(RuntimeError)
         end
-
       end
-
     end
 
     context "when given a host without a pe_dir" do
-
-      let!(:invalid_host) {{"pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM}}
+      let!(:invalid_host) { { "pe_ver" => TEST_PE_VER, "platform" => TEST_PLATFORM } }
 
       it "it raises an error" do
         expect(url_helper).not_to receive(:link_exists?)
-        expect{url_helper.get_ras_pe_tarball_url(invalid_host)}.to raise_error(RuntimeError)
+        expect { url_helper.get_ras_pe_tarball_url(invalid_host) }.to raise_error(RuntimeError)
       end
-
     end
 
     context "when given a host without a pe_ver" do
-
-      let!(:invalid_host) {{"pe_dir" => TEST_PE_DIR, "platform" => TEST_PLATFORM}}
+      let!(:invalid_host) { { "pe_dir" => TEST_PE_DIR, "platform" => TEST_PLATFORM } }
 
       it "it raises an error" do
         expect(url_helper).not_to receive(:link_exists?)
-        expect{url_helper.get_ras_pe_tarball_url(invalid_host)}.to raise_error(RuntimeError)
+        expect { url_helper.get_ras_pe_tarball_url(invalid_host) }.to raise_error(RuntimeError)
       end
-
     end
 
     context "when given a host without a platform" do
-
-      let!(:invalid_host) {{"pe_dir" => TEST_PE_DIR, "pe_ver" => TEST_PE_VER}}
+      let!(:invalid_host) { { "pe_dir" => TEST_PE_DIR, "pe_ver" => TEST_PE_VER } }
 
       it "it raises an error" do
         expect(url_helper).not_to receive(:link_exists?)
-        expect{url_helper.get_ras_pe_tarball_url(invalid_host)}.to raise_error(RuntimeError)
+        expect { url_helper.get_ras_pe_tarball_url(invalid_host) }.to raise_error(RuntimeError)
       end
-
     end
-
   end
-
 end

--- a/spec/ref_arch_setup/url_helper_spec.rb
+++ b/spec/ref_arch_setup/url_helper_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../lib/ref_arch_setup/url_helper.rb"
 describe RefArchSetup::UrlHelper do
   let(:url_helper) { RefArchSetup::UrlHelper.new }
 
-  TEST_PE_DIR = "http://enterprise.delivery.puppetlabs.net/archives/internal/2018.1".freeze
+  TEST_PE_DIR = "http://test.net/2018.1".freeze
   TEST_PE_VER = "2018.1.0-rc14".freeze
   TEST_PLATFORM = "el-6-x86_64".freeze
   TEST_DIST = "puppet-enterprise-2018.1.0-rc14-el-6-x86_64".freeze

--- a/spec/ref_arch_setup/url_helper_spec.rb
+++ b/spec/ref_arch_setup/url_helper_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe RefArchSetup::UrlHelper do
+
+  let(:url_helper) { RefArchSetup::UrlHelper.new() }
+
+  TEST_PE_DIR = "http://enterprise.delivery.puppetlabs.net/archives/internal/2018.1".freeze
+  TEST_PE_VER = "2018.1.0-rc14".freeze
+  TEST_HOST = "el-6-x86_64".freeze
+  TEST_EXPECTED_URL = "http://enterprise.delivery.puppetlabs.net/archives/internal/2018.1/puppet-enterprise-2018.1.0-rc14-el-6-x86_64.tar.gz"
+
+  describe "#get_url" do
+
+    context "when given a pe_dir, pe_ver, and host" do
+
+      it "it returns the download URL" do
+
+        expect(url_helper.get_url(TEST_PE_DIR, TEST_PE_VER, TEST_HOST)).to eq(TEST_EXPECTED_URL)
+
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
Unfortunately there isn't a specific method in Beaker that builds and returns a tarball URL. The code that derives the URL is contained within the same 'fetch' method that downloads and extracts the tarball. However, it would be easy to duplicate the relevant code; better yet, the existing code could be fairly easily refactored to isolate the URL creation functionality and allow it to be called separately.

Currenty gplt initiates the installation in `00_install_pe` by calling `install_lei` in `beaker-pe-large-environments`. This eventually leads to `simple_monolithic_install`:

```
00_install_pe > install_lei > install_lei_on > install_pe_on > do_install > simple_monolithic_install
```

`simple_monolithic_install` calls two methods that are relevant for our purpose of deriving the tarball URL, `prepare_hosts` and `fetch_pe`:

* `prepare_hosts(all_hosts, opts)`

This is where the `host['dist']` value is set; this value is later used to build the URL:

```
if should_install_64bit
  host['dist'] = "puppet-agent-#{version}-x64"
else
  host['dist'] = "puppet-agent-#{version}-x86"
end
```
This method contains logic to determine the platform type, but since we're trying to determine a tarball URL we already know the platform is not windows or osx.

* `fetch_pe([master], opts)`

This method calls a corresponding platform-specific fetch method which downloads and extracts the tarball:

`fetch_pe_on_unix(host, opts)`

This method contains platform-based logic to determine the extension, but since we want a tarball URL we know the extension will be `.tar.gz`.

The relevant part of this method is that it builds the URL based on the following values:

```
path = host['pe_dir']
filename = host['dist']
extension = ".tar.gz"
...
url = "#{path}/#{filename}#{extension}"
```

Since this will be a Beaker method the pe_dir and pe_ver will be specified as host parameters, and the value for host['dist'] can be provided by a method that extracts the functionality from `prepare_hosts`.
