### PR TITLE
(SLV-153) Upgrade bootstrap to handle PE tarballs other than on the target host

### DIFF
--- a/lib/ref_arch_setup/install.rb
+++ b/lib/ref_arch_setup/install.rb
@@ -113,11 +113,11 @@ module RefArchSetup
     #
     # @author Bill Claytor
     #
-    # @param [string] url Path to PE tarball file
+    # @param [string] url URL for the PE tarball file
     #
     # @raise [RuntimeError] Based on the validity of the url
     #
-    # @return [true] Based on the validity of the extension
+    # @return [true] Based on the validity of the URL
     def parse_url(url)
       begin
         @pe_tarball_uri = URI.parse(url)
@@ -137,7 +137,7 @@ module RefArchSetup
     # @raise [RuntimeError] Based on the validity of the extension
     #
     # @return [true] Based on the validity of the extension
-    def validate_extension(pe_tarball)
+    def validate_tarball_extension(pe_tarball)
       message = "Invalid extension for tarball: #{pe_tarball}; extension must be .tar.gz"
       raise(message) unless pe_tarball.end_with?(".tar.gz")
       return true
@@ -229,7 +229,7 @@ module RefArchSetup
       else
         # if downloading to the target master fails try to download locally and then upload
         success = download_pe_tarball(url, @target_master)
-        puts "Unable to download the tarball directly to localhost" unless success
+        puts "Unable to download the tarball directly to #{@target_master}" unless success
         success = download_and_move_pe_tarball(url) unless success
         raise remote_error unless success
       end
@@ -242,11 +242,11 @@ module RefArchSetup
     #
     # @author Bill Claytor
     #
-    # @param [string] path The pe tarball path
+    # @param [string] tarball_path_on_target_master The pe tarball path on the target master
     #
     # @return [true,false] Based on exit status of the bolt task
-    def copy_pe_tarball_on_target_master(path)
-      command = "cp #{path} #{TMP_WORK_DIR}"
+    def copy_pe_tarball_on_target_master(tarball_path_on_target_master)
+      command = "cp #{tarball_path_on_target_master} #{TMP_WORK_DIR}"
       success = BoltHelper.run_cmd_with_bolt(command, @target_master)
       return success
     end
@@ -313,7 +313,7 @@ module RefArchSetup
     # @return [string] The tarball path on the master after copying if successful
     def handle_pe_tarball(pe_tarball)
       error = "Unable to handle the specified PE tarball path: #{pe_tarball}"
-      validate_extension(pe_tarball)
+      validate_tarball_extension(pe_tarball)
       tarball_path_on_master = if valid_url?(pe_tarball)
                                  handle_tarball_url(pe_tarball)
                                else

--- a/lib/ref_arch_setup/install.rb
+++ b/lib/ref_arch_setup/install.rb
@@ -8,6 +8,7 @@ module RefArchSetup
   # @author Randell Pelak
   #
   # @attr [string] target_master Host to install on
+  # rubocop:disable Metrics/ClassLength
   class Install
     # Initialize class
     #
@@ -100,13 +101,12 @@ module RefArchSetup
     #
     # @return [true,false] Based on the validity of the extension
     def valid_extension?(pe_tarball_path)
-      valid = false
-      extension = File.extname(pe_tarball_path)
-      if extension == ".gz"
+      if pe_tarball_path.end_with?(".tar.gz")
         valid = true
       else
-        puts "Invalid extension: #{extension} for URL: #{pe_tarball_path}."
-        puts "Extension must be .gz"
+        valid = false
+        puts "Invalid extension for tarball: #{pe_tarball_path}."
+        puts "Extension must be .tar.gz"
         puts
       end
       valid
@@ -138,6 +138,7 @@ module RefArchSetup
       puts "Attempting to download #{url} to #{nodes}"
       puts
 
+      params = {}
       params["url"] = url
       params["destination"] = TMP_WORK_DIR
 
@@ -159,7 +160,7 @@ module RefArchSetup
       puts
 
       success = download_pe_tarball(url, "localhost")
-      success = upload_pe_tarball("#{TMP_WORK_DIR}/#{filename}") if success
+      success = upload_pe_tarball("#{TMP_WORK_DIR}/#{filename}", target_master) if success
       return success
     end
 
@@ -173,7 +174,7 @@ module RefArchSetup
     #
     # @return [true,false] Based on exit status of the bolt task
     def handle_tarball_url(url, target_master)
-      uri = URI.parse(pe_tarball_path)
+      uri = URI.parse(url)
       filename = File.basename(uri.path)
 
       # TODO: improve check for localhost

--- a/ref_arch_setup.gemspec
+++ b/ref_arch_setup.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   # Ensure the gem is build out of the versioned files
   spec.files            = Dir["CONTRIBUTING.md", "LICENSE.md", "MAINTAINERS",
-                              "README.md", "lib/**/*", "bin/*", "docs/**/*"]
+                              "README.md", "lib/**/*", "bin/*", "docs/**/*", "modules/**/*"]
   spec.executables   = ["ref_arch_setup"]
   spec.require_paths = ["lib"]
 

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -478,8 +478,11 @@ describe RefArchSetup::Install do
             .with(pe_tarball_path, remote_target_master).and_return(false)
 
           expect(install).not_to receive(:copy_pe_tarball)
+
+          # TODO: rubocop Metrics/LineLength?
           expect(install.handle_tarball_with_remote_target_master(@remote_tarball_path, \
-                                                                  remote_target_master)).to eq(false)
+                                                                  remote_target_master))
+            .to eq(false)
         end
       end
     end
@@ -514,8 +517,10 @@ describe RefArchSetup::Install do
           expect(install).to receive(:upload_pe_tarball)
             .with(pe_tarball_path).and_return(false)
 
+          # TODO: rubocop Metrics/LineLength?
           expect(install.handle_tarball_with_remote_target_master(pe_tarball_path, \
-                                                                  remote_target_master)).to eq(false)
+                                                                  remote_target_master))
+            .to eq(false)
         end
       end
     end
@@ -573,7 +578,8 @@ describe RefArchSetup::Install do
           expect(install).to receive(:handle_tarball_with_remote_target_master)
             .with(pe_tarball_path, remote_target_master).and_return(true)
 
-          expect(install.handle_tarball_path(pe_tarball_path, remote_target_master)).to eq(pe_tarball_filename)
+          expect(install.handle_tarball_path(pe_tarball_path, remote_target_master))
+            .to eq(pe_tarball_filename)
         end
       end
 
@@ -602,7 +608,8 @@ describe RefArchSetup::Install do
             expect(install).to receive(:handle_tarball_url).with(pe_tarball_url, target_master)
                                                            .and_return(pe_tarball_filename)
 
-            expect(install.handle_pe_tarball(pe_tarball_url, target_master)).to eq(master_tarball_path)
+            expect(install.handle_pe_tarball(pe_tarball_url, target_master))
+              .to eq(master_tarball_path)
           end
         end
 
@@ -627,7 +634,8 @@ describe RefArchSetup::Install do
             expect(install).to receive(:handle_tarball_path).with(pe_tarball_path, target_master)
                                                             .and_return(pe_tarball_filename)
 
-            expect(install.handle_pe_tarball(pe_tarball_path, target_master)).to eq(master_tarball_path)
+            expect(install.handle_pe_tarball(pe_tarball_path, target_master))
+              .to eq(master_tarball_path)
           end
         end
 

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -261,23 +261,23 @@ describe RefArchSetup::Install do
     end
   end
 
-  describe "#validate_extension" do
+  describe "#validate_tarball_extension" do
     context "when given a path ending with .tar.gz" do
       it "returns true" do
-        expect(install.validate_extension(pe_tarball)).to eq(true)
+        expect(install.validate_tarball_extension(pe_tarball)).to eq(true)
       end
     end
 
     context "when given a url ending with .tar.gz" do
       it "returns true" do
-        expect(install.validate_extension(pe_tarball_url)).to eq(true)
+        expect(install.validate_tarball_extension(pe_tarball_url)).to eq(true)
       end
     end
 
     context "when given a path not ending in .tar.gz" do
       it "raises an error" do
         path = "/tmp/file.txt"
-        expect { install.validate_extension(path) }.to raise_error(RuntimeError)
+        expect { install.validate_tarball_extension(path) }.to raise_error(RuntimeError)
       end
     end
   end
@@ -531,7 +531,7 @@ describe RefArchSetup::Install do
     end
   end
 
-  describe "#handle_tarball_with_remote_target_master" do
+  describe "#handle_tarball_path_with_remote_target_master" do
     before do
       install.instance_variable_set(:@target_master, remote_target_master)
       @remote_flag = "#{remote_target_master}:"
@@ -695,7 +695,7 @@ describe RefArchSetup::Install do
       context "when the tarball path is a valid URL" do
         context "when the tarball URL is handled successfully" do
           it "returns the tarball path on the master" do
-            expect(install).to receive(:validate_extension).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:validate_tarball_extension).with(pe_tarball_url).and_return(true)
             expect(install).to receive(:valid_url?).with(pe_tarball_url).and_return(true)
             expect(install).to receive(:handle_tarball_url)
               .with(pe_tarball_url).and_return(tarball_path_on_master)
@@ -707,7 +707,7 @@ describe RefArchSetup::Install do
 
         context "when the tarball URL is not handled successfully" do
           it "raises an error" do
-            expect(install).to receive(:validate_extension).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:validate_tarball_extension).with(pe_tarball_url).and_return(true)
             expect(install).to receive(:valid_url?).with(pe_tarball_url).and_return(true)
             expect(install).to receive(:handle_tarball_url).with(pe_tarball_url).and_return(nil)
 
@@ -720,7 +720,7 @@ describe RefArchSetup::Install do
       context "when the tarball path is not a valid URL and a path is assumed" do
         context "when the tarball path is handled successfully" do
           it "returns the tarball path on the master" do
-            expect(install).to receive(:validate_extension).with(pe_tarball).and_return(true)
+            expect(install).to receive(:validate_tarball_extension).with(pe_tarball).and_return(true)
             expect(install).to receive(:valid_url?).with(pe_tarball).and_return(false)
             expect(install).to receive(:handle_tarball_path)
               .with(pe_tarball).and_return(tarball_path_on_master)
@@ -732,7 +732,7 @@ describe RefArchSetup::Install do
 
         context "when the tarball path is not handled successfully" do
           it "raises an error" do
-            expect(install).to receive(:validate_extension).with(pe_tarball).and_return(true)
+            expect(install).to receive(:validate_tarball_extension).with(pe_tarball).and_return(true)
             expect(install).to receive(:valid_url?).with(pe_tarball).and_return(false)
             expect(install).to receive(:handle_tarball_path).with(pe_tarball).and_return(nil)
 
@@ -746,7 +746,7 @@ describe RefArchSetup::Install do
     context "when the extension is not valid" do
       it "raises an error" do
         path = "/tmp/invalid"
-        expect(install).to receive(:validate_extension).with(path).and_raise(RuntimeError)
+        expect(install).to receive(:validate_tarball_extension).with(path).and_raise(RuntimeError)
         expect { install.handle_pe_tarball(path) }
           .to raise_error(RuntimeError)
       end

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -695,7 +695,8 @@ describe RefArchSetup::Install do
       context "when the tarball path is a valid URL" do
         context "when the tarball URL is handled successfully" do
           it "returns the tarball path on the master" do
-            expect(install).to receive(:validate_tarball_extension).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:validate_tarball_extension)
+              .with(pe_tarball_url).and_return(true)
             expect(install).to receive(:valid_url?).with(pe_tarball_url).and_return(true)
             expect(install).to receive(:handle_tarball_url)
               .with(pe_tarball_url).and_return(tarball_path_on_master)
@@ -707,7 +708,8 @@ describe RefArchSetup::Install do
 
         context "when the tarball URL is not handled successfully" do
           it "raises an error" do
-            expect(install).to receive(:validate_tarball_extension).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:validate_tarball_extension)
+              .with(pe_tarball_url).and_return(true)
             expect(install).to receive(:valid_url?).with(pe_tarball_url).and_return(true)
             expect(install).to receive(:handle_tarball_url).with(pe_tarball_url).and_return(nil)
 
@@ -720,7 +722,8 @@ describe RefArchSetup::Install do
       context "when the tarball path is not a valid URL and a path is assumed" do
         context "when the tarball path is handled successfully" do
           it "returns the tarball path on the master" do
-            expect(install).to receive(:validate_tarball_extension).with(pe_tarball).and_return(true)
+            expect(install).to receive(:validate_tarball_extension)
+              .with(pe_tarball).and_return(true)
             expect(install).to receive(:valid_url?).with(pe_tarball).and_return(false)
             expect(install).to receive(:handle_tarball_path)
               .with(pe_tarball).and_return(tarball_path_on_master)
@@ -732,7 +735,8 @@ describe RefArchSetup::Install do
 
         context "when the tarball path is not handled successfully" do
           it "raises an error" do
-            expect(install).to receive(:validate_tarball_extension).with(pe_tarball).and_return(true)
+            expect(install).to receive(:validate_tarball_extension)
+              .with(pe_tarball).and_return(true)
             expect(install).to receive(:valid_url?).with(pe_tarball).and_return(false)
             expect(install).to receive(:handle_tarball_path).with(pe_tarball).and_return(nil)
 

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -4,33 +4,27 @@ describe RefArchSetup::Install do
   let(:target_master) { "local://localhost" }
   let(:remote_target_master) { "remote.target.master" }
   let(:pe_conf_path) { "/tmp/pe.conf" }
+  let(:conf_path_on_master) { "#{tmp_work_dir}/pe.conf" }
   let(:pe_tarball_filename) { "pe.tarball.tar.gz" }
-  let(:pe_tarball_path) { "/tmp/#{pe_tarball_filename}" }
-  let(:master_tarball_path) { "/tmp/ref_arch_setup/#{pe_tarball_filename}" }
+  let(:pe_tarball) { "/tmp/#{pe_tarball_filename}" }
+  let(:tmp_work_dir) { "/tmp/ref_arch_setup" }
+  # TODO: tarball_path_on_master vs. target_master_pe_tarball?
+  let(:tarball_path_on_master) { "#{tmp_work_dir}/#{pe_tarball_filename}" }
   let(:install) { RefArchSetup::Install.new(target_master) }
   let(:install_task) { "ref_arch_setup::install_pe" }
   let(:install_task_params) do
-    { "pe_conf_path" => pe_conf_path, "pe_tarball_path" => master_tarball_path }
+    { "pe_conf_path" => conf_path_on_master, "pe_tarball" => tarball_path_on_master }
   end
 
-  # TODO: remove?
-  # let(:params_str) do
-  #   "pe_conf_path=#{pe_tarball_path} pe_tarball_path=#{pe_tarball_path} " \
-  #     "pe_target_master=#{target_master}"
-  # end
+  let(:pe_tarball_url) { "https://test.net/2018.1/#{pe_tarball_filename}" }
+  let(:pe_tarball_http_url) { "http://test.net/2018.1/#{pe_tarball_filename}" }
 
-  let(:pe_tarball_url) { "https://test.net/2018.1/pe.tar.gz" }
-  let(:tmp_work_dir) { "/tmp/ref_arch_setup" }
   let(:download_task) { "ref_arch_setup::download_pe_tarball" }
   let(:download_task_params) do
     { "url" => pe_tarball_url, "destination" => tmp_work_dir }
   end
 
   let(:test_uri) { Class.new }
-
-  TEST_HTTP_URL = "http://test.net/2018.1/pe.tar.gz".freeze
-  TEST_HTTPS_URL = "https://test.net/2018.1/pe.tar.gz".freeze
-  # TEST_MASTER_TARBALL_PATH = "/tmp/ref_arch_setup/pe.tarball.tar.gz".freeze
 
   describe "initialize" do
     it "checks that the passed in parameters get used" do
@@ -40,25 +34,17 @@ describe RefArchSetup::Install do
   end
 
   describe "bootstrap" do
-    # TODO: remove?
-    # before do
-    #   @expected_command = "bolt task run #{install_task} "
-    #   @expected_command << params_str
-    #   @expected_command << " --modulepath #{RefArchSetup::RAS_MODULE_PATH}"
-    #   @expected_command << " --nodes #{target_master}"
-    # end
-
     context "when make_temp_dir and handle_pe_conf do not raise errors" do
       context "when called using default value" do
         context "when run_task_with_bolt returned true" do
           it "returns true" do
             expect(install).to receive(:make_tmp_work_dir).and_return(true)
-            expect(install).to receive(:handle_pe_conf).and_return(true)
-            expect(install).to receive(:handle_pe_tarball).and_return(master_tarball_path)
+            expect(install).to receive(:handle_pe_conf).and_return(conf_path_on_master)
+            expect(install).to receive(:handle_pe_tarball).and_return(tarball_path_on_master)
             expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
               .with(install_task, install_task_params, target_master)
               .and_return(true)
-            expect(install.bootstrap(pe_conf_path, pe_tarball_path)).to eq(true)
+            expect(install.bootstrap(pe_conf_path, pe_tarball)).to eq(true)
           end
         end
       end
@@ -67,22 +53,22 @@ describe RefArchSetup::Install do
         context "when run_task_with_bolt returned true" do
           it "returns true" do
             expect(install).to receive(:make_tmp_work_dir).and_return(true)
-            expect(install).to receive(:handle_pe_conf).and_return(true)
-            expect(install).to receive(:handle_pe_tarball).and_return(master_tarball_path)
+            expect(install).to receive(:handle_pe_conf).and_return(conf_path_on_master)
+            expect(install).to receive(:handle_pe_tarball).and_return(tarball_path_on_master)
             expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
               .with(install_task, install_task_params, target_master).and_return(true)
-            expect(install.bootstrap(pe_conf_path, pe_tarball_path, target_master)).to eq(true)
+            expect(install.bootstrap(pe_conf_path, pe_tarball)).to eq(true)
           end
         end
 
         context "when run_task_with_bolt returned false" do
           it "returns false" do
             expect(install).to receive(:make_tmp_work_dir).and_return(true)
-            expect(install).to receive(:handle_pe_conf).and_return(true)
-            expect(install).to receive(:handle_pe_tarball).and_return(master_tarball_path)
+            expect(install).to receive(:handle_pe_conf).and_return(conf_path_on_master)
+            expect(install).to receive(:handle_pe_tarball).and_return(tarball_path_on_master)
             expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
               .with(install_task, install_task_params, target_master).and_return(false)
-            expect(install.bootstrap(pe_conf_path, pe_tarball_path, target_master)).to eq(false)
+            expect(install.bootstrap(pe_conf_path, pe_tarball)).to eq(false)
           end
         end
       end
@@ -91,8 +77,7 @@ describe RefArchSetup::Install do
     context "When make_tmp_dir raises an error" do
       it "should not be trapped" do
         expect(install).to receive(:make_tmp_work_dir).and_raise(RuntimeError)
-        expect { install.bootstrap(pe_conf_path, pe_tarball_path, target_master) }.to \
-          raise_error(RuntimeError)
+        expect { install.bootstrap(pe_conf_path, pe_tarball) }.to raise_error(RuntimeError)
       end
     end
 
@@ -100,8 +85,72 @@ describe RefArchSetup::Install do
       it "should not be trapped" do
         expect(install).to receive(:make_tmp_work_dir).and_return(true)
         expect(install).to receive(:handle_pe_conf).and_raise(RuntimeError)
-        expect { install.bootstrap(pe_conf_path, pe_tarball_path, target_master) }.to \
-          raise_error(RuntimeError)
+        expect { install.bootstrap(pe_conf_path, pe_tarball) }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  describe "handle_pe_conf_path" do
+    context "When user gave a value for pe.conf that is a directory" do
+      context "When a pe.conf is found in the dir" do
+        it "returns the file path" do
+          tmpdir = "/tmp/foo"
+          file_path = "#{tmpdir}/pe.conf"
+          expect(File).to receive(:expand_path).with(tmpdir).and_return(tmpdir)
+          expect(File).to receive(:directory?).with(tmpdir).and_return(true)
+          expect(File).to receive(:exist?).with(file_path).and_return(true)
+          expect(install.handle_pe_conf_path(tmpdir)).to eq(file_path)
+        end
+      end
+      context "When a pe.conf is NOT found in the dir" do
+        it "raises an error" do
+          tmpdir = "/tmp/foo"
+          file_path = "#{tmpdir}/pe.conf"
+          expect(File).to receive(:expand_path).with(tmpdir).and_return(tmpdir)
+          expect(File).to receive(:directory?).with(tmpdir).and_return(true)
+          expect(File).to receive(:exist?).with(file_path).and_return(false)
+          expect { install.handle_pe_conf_path(tmpdir) }.to \
+            raise_error(RuntimeError, /No pe.conf file found in directory: #{tmpdir}/)
+        end
+      end
+    end
+    context "When user gave a value that is not a directory" do
+      context "When the file is found" do
+        it "returns the file path" do
+          tmpdir = "/tmp/foo"
+          file_path = "#{tmpdir}/pe.conf"
+          expect(File).to receive(:expand_path).with(file_path).and_return(file_path)
+          expect(File).to receive(:directory?).with(file_path).and_return(false)
+          expect(File).to receive(:basename).with(file_path).and_return("pe.conf")
+          expect(File).to receive(:exist?).with(file_path).and_return(true)
+          expect(install.handle_pe_conf_path(file_path)).to eq(file_path)
+        end
+      end
+      context "When the file is NOT found" do
+        it "raises an error" do
+          tmpdir = "/tmp/foo"
+          file_path = "#{tmpdir}/pe.conf"
+          expect(File).to receive(:expand_path).with(file_path).and_return(file_path)
+          expect(File).to receive(:directory?).with(file_path).and_return(false)
+          expect(File).to receive(:basename).with(file_path).and_return("pe.conf")
+          expect(File).to receive(:exist?).with(file_path).and_return(false)
+          expect { install.handle_pe_conf_path(file_path) }.to \
+            raise_error(RuntimeError, /pe.conf file not found #{file_path}/)
+        end
+      end
+    end
+
+    context "When the file is not named pe.conf" do
+      it "raises an error" do
+        tmpdir = "/tmp/foo"
+        file_path = "#{tmpdir}/not_pe.conf"
+        expect(File).to receive(:expand_path).with(file_path).and_return(file_path)
+        expect(File).to receive(:directory?).with(file_path).and_return(false)
+        expect(File).to receive(:basename).with(file_path).and_return("not_pe.conf")
+        expect(File).not_to receive(:exist?)
+        expect(install).not_to receive(:upload_pe_conf)
+        expect { install.handle_pe_conf_path(file_path) }.to \
+          raise_error(RuntimeError, /Specified file is not named pe.conf/)
       end
     end
   end
@@ -115,7 +164,7 @@ describe RefArchSetup::Install do
           expect(Dir).to receive(:pwd).and_return(tmpdir)
           expect(File).to receive(:exist?).with(file_path).and_return(true)
           expect(install).to receive(:upload_pe_conf).with(file_path).and_return(true)
-          expect(install.handle_pe_conf(nil)).to eq(true)
+          expect(install.handle_pe_conf(nil)).to eq(conf_path_on_master)
         end
       end
       context "When pe.conf does not exist in the CWD" do
@@ -134,22 +183,19 @@ describe RefArchSetup::Install do
         it "calls upload on it and returns true" do
           tmpdir = "/tmp/foo"
           file_path = "#{tmpdir}/pe.conf"
-          expect(File).to receive(:expand_path).with(tmpdir).and_return(tmpdir)
-          expect(File).to receive(:directory?).with(tmpdir).and_return(true)
-          expect(File).to receive(:exist?).with(file_path).and_return(true)
+          expect(install).to receive(:handle_pe_conf_path).with(tmpdir).and_return(file_path)
           expect(install).to receive(:upload_pe_conf).with(file_path).and_return(true)
-          expect(install.handle_pe_conf(tmpdir)).to eq(true)
+          expect(install.handle_pe_conf(tmpdir)).to eq(conf_path_on_master)
         end
       end
       context "When a pe.conf is NOT found in the dir" do
         it "raises an error" do
           tmpdir = "/tmp/foo"
-          file_path = "#{tmpdir}/pe.conf"
-          expect(File).to receive(:expand_path).with(tmpdir).and_return(tmpdir)
-          expect(File).to receive(:directory?).with(tmpdir).and_return(true)
-          expect(File).to receive(:exist?).with(file_path).and_return(false)
-          expect { install.handle_pe_conf(tmpdir) }.to \
-            raise_error(RuntimeError, /No pe.conf file found in directory: #{tmpdir}/)
+          expect(install).to receive(:handle_pe_conf_path)
+            .with(tmpdir).and_raise(RuntimeError, /No pe.conf file found in directory: #{tmpdir}/)
+
+          expect(install).not_to receive(:upload_pe_conf)
+          expect { install.handle_pe_conf(tmpdir) }.to raise_error(RuntimeError)
         end
       end
     end
@@ -158,106 +204,153 @@ describe RefArchSetup::Install do
         it "calls upload on it and returns true" do
           tmpdir = "/tmp/foo"
           file_path = "#{tmpdir}/pe.conf"
-          expect(File).to receive(:expand_path).with(file_path).and_return(file_path)
-          expect(File).to receive(:directory?).with(file_path).and_return(false)
-          expect(File).to receive(:exist?).with(file_path).and_return(true)
+          expect(install).to receive(:handle_pe_conf_path).with(file_path).and_return(file_path)
           expect(install).to receive(:upload_pe_conf).with(file_path).and_return(true)
-          expect(install.handle_pe_conf(file_path)).to eq(true)
+          expect(install.handle_pe_conf(file_path)).to eq(conf_path_on_master)
         end
       end
       context "When the file is NOT found" do
         it "raises an error" do
           tmpdir = "/tmp/foo"
           file_path = "#{tmpdir}/pe.conf"
-          expect(File).to receive(:expand_path).with(file_path).and_return(file_path)
-          expect(File).to receive(:directory?).with(file_path).and_return(false)
-          expect(File).to receive(:exist?).with(file_path).and_return(false)
-          expect { install.handle_pe_conf(file_path) }.to \
-            raise_error(RuntimeError, /pe.conf file not found #{file_path}/)
+
+          expect(install).to receive(:handle_pe_conf_path)
+            .with(file_path).and_raise(RuntimeError, /pe.conf file not found #{file_path}/)
+
+          expect(install).not_to receive(:upload_pe_conf)
+          expect { install.handle_pe_conf(file_path) }.to raise_error(RuntimeError)
         end
+      end
+    end
+    context "When the upload is not successful" do
+      it "raises an error" do
+        tmpdir = "/tmp/foo"
+        file_path = "#{tmpdir}/pe.conf"
+        expect(install).to receive(:handle_pe_conf_path).with(file_path).and_return(file_path)
+        expect(install).to receive(:upload_pe_conf).with(file_path).and_return(false)
+        expect { install.handle_pe_conf(file_path) }.to \
+          raise_error(RuntimeError, /Unable to upload pe.conf file to #{target_master}/)
+      end
+    end
+    context "When the file is not named pe.conf" do
+      it "raises an error" do
+        tmpdir = "/tmp/foo"
+        file_path = "#{tmpdir}/not_pe.conf"
+
+        expect(install).to receive(:handle_pe_conf_path)
+          .with(file_path).and_raise(RuntimeError, /Specified file is not named pe.conf/)
+
+        expect(install).not_to receive(:upload_pe_conf)
+        expect { install.handle_pe_conf(file_path) }.to raise_error(RuntimeError)
       end
     end
   end
 
   # TODO: mock URI?
-  describe "#valid_tarball_url?" do
+  describe "#valid_url?" do
     context "when given a url starting with http" do
       it "returns true" do
-        expect(install.valid_tarball_url?(TEST_HTTP_URL)).to eq(true)
+        # expect(install).to receive(:validate_extension)
+        #   .with(pe_tarball_http_url)
+        #   .and_return(true)
+        expect(install.valid_url?(pe_tarball_http_url)).to eq(true)
       end
     end
 
     context "when given a url starting with https" do
       it "returns true" do
-        expect(install.valid_tarball_url?(TEST_HTTPS_URL)).to eq(true)
+        expect(install.valid_url?(pe_tarball_url)).to eq(true)
       end
     end
 
     context "when given an invalid url" do
       it "returns false" do
-        expect(install.valid_tarball_url?(pe_tarball_path)).to eq(false)
+        expect(install.valid_url?(pe_tarball)).to eq(false)
       end
     end
   end
 
-  describe "#valid_extension??" do
+  describe "#validate_extension" do
     context "when given a path ending with .tar.gz" do
-      it "returns true" do
-        expect(install.valid_extension?(pe_tarball_path)).to eq(true)
+      it "returns nothing" do
+        expect(install.validate_extension(pe_tarball)).to eq(true)
       end
     end
 
     context "when given a url ending with .tar.gz" do
       it "returns true" do
-        expect(install.valid_extension?(TEST_HTTPS_URL)).to eq(true)
+        expect(install.validate_extension(pe_tarball_url)).to eq(true)
       end
     end
 
     context "when given a path not ending in .tar.gz" do
-      it "reports the error and returns false" do
+      it "raises an error" do
         path = "/tmp/file.txt"
-        message1 = "Invalid extension for tarball: #{path}."
-        message2 = "Extension must be .tar.gz"
-
-        allow(install).to receive(:puts)
-        expect(install).to receive(:puts).with(message1)
-        expect(install).to receive(:puts).with(message2)
-        expect(install.valid_extension?(path)).to eq(false)
+        expect { install.validate_extension(path) }.to raise_error(RuntimeError)
       end
     end
   end
 
-  describe "#file_exist_on_target_master??" do
+  describe "#parse_url" do
+    context "when given a valid url" do
+      it "sets the instance variables and returns true" do
+        # TODO: verify instance variables
+        expect(install.parse_url(pe_tarball_url)).to eq(true)
+      end
+    end
+
+    context "when given an invalid url" do
+      it "raises an error" do
+        expect { install.parse_url(nil) }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  describe "#target_master_is_localhost?" do
+    context "when the target master is localhost" do
+      it "returns true" do
+        install.instance_variable_set(:@target_master, target_master)
+        expect(install.target_master_is_localhost?).to eq(true)
+      end
+    end
+
+    context "when the target master is not localhost" do
+      it "returns false" do
+        install.instance_variable_set(:@target_master, remote_target_master)
+        expect(install.target_master_is_localhost?).to eq(false)
+      end
+    end
+  end
+
+  describe "#file_exist_on_target_master?" do
     before do
-      @command = "[ -f #{pe_tarball_path} ]"
+      @command = "[ -f #{pe_tarball} ]"
     end
 
     context "when the file exists on the target master" do
       it "returns true" do
         expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)
-          .with(@command, target_master)
-          .and_return(true)
-        expect(install.file_exist_on_target_master?(pe_tarball_path, target_master)).to eq(true)
+          .with(@command, target_master).and_return(true)
+        expect(install.file_exist_on_target_master?(pe_tarball)).to eq(true)
       end
     end
 
     context "when the file does not exist on the target master" do
       it "returns false" do
         expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)
-          .with(@command, target_master)
-          .and_return(false)
-        expect(install.file_exist_on_target_master?(pe_tarball_path, target_master)).to eq(false)
+          .with(@command, target_master).and_return(false)
+        expect(install.file_exist_on_target_master?(pe_tarball)).to eq(false)
       end
     end
   end
 
-  describe "#download_pe_tarball??" do
+  describe "#download_pe_tarball" do
     context "when the download is successful" do
       it "returns true" do
         allow(install).to receive(:puts)
         expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
           .with(download_task, download_task_params, target_master).and_return(true)
-        expect(install.download_pe_tarball(TEST_HTTPS_URL, target_master)).to eq(true)
+        expect(install.download_pe_tarball(pe_tarball_url, target_master)).to eq(true)
       end
     end
 
@@ -266,35 +359,36 @@ describe RefArchSetup::Install do
         allow(install).to receive(:puts)
         expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
           .with(download_task, download_task_params, target_master).and_return(false)
-        expect(install.download_pe_tarball(TEST_HTTPS_URL, target_master)).to eq(false)
+        expect(install.download_pe_tarball(pe_tarball_url, target_master)).to eq(false)
       end
     end
   end
 
   describe "#download_and_move_pe_tarball" do
+    before do
+      install.instance_variable_set(:@pe_tarball_filename, pe_tarball_filename)
+      install.instance_variable_set(:@target_master, remote_target_master)
+    end
     context "when the download is successful" do
       context "when the upload is successful" do
         it "returns true" do
           allow(install).to receive(:puts)
-          expect(install).to receive(:download_pe_tarball).with(TEST_HTTPS_URL, "localhost")
-                                                          .and_return(true)
-          expect(install).to receive(:upload_pe_tarball).with(master_tarball_path, target_master)
-                                                        .and_return(true)
-          expect(install.download_and_move_pe_tarball(TEST_HTTPS_URL, pe_tarball_filename, \
-                                                      target_master)).to eq(true)
+          expect(install).to receive(:download_pe_tarball)
+            .with(pe_tarball_url, "localhost").and_return(true)
+          expect(install).to receive(:upload_pe_tarball)
+            .with(tarball_path_on_master).and_return(true)
+          expect(install.download_and_move_pe_tarball(pe_tarball_url)).to eq(true)
         end
       end
 
       context "when the upload is not successful" do
         it "returns false" do
           allow(install).to receive(:puts)
-          expect(install).to receive(:download_pe_tarball).with(TEST_HTTPS_URL, "localhost")
-                                                          .and_return(true)
-          expect(install).to receive(:upload_pe_tarball).with(master_tarball_path, target_master)
-                                                        .and_return(false)
-          expect(install.download_and_move_pe_tarball(TEST_HTTPS_URL, pe_tarball_filename, \
-                                                      target_master))
-            .to eq(false)
+          expect(install).to receive(:download_pe_tarball)
+            .with(pe_tarball_url, "localhost").and_return(true)
+          expect(install).to receive(:upload_pe_tarball)
+            .with(tarball_path_on_master).and_return(false)
+          expect(install.download_and_move_pe_tarball(pe_tarball_url)).to eq(false)
         end
       end
     end
@@ -302,167 +396,170 @@ describe RefArchSetup::Install do
     context "when the download is not successful" do
       it "does not attempt to upload and returns false" do
         allow(install).to receive(:puts)
-        expect(install).to receive(:download_pe_tarball).with(TEST_HTTPS_URL, "localhost")
+        expect(install).to receive(:download_pe_tarball).with(pe_tarball_url, "localhost")
                                                         .and_return(false)
         expect(install).not_to receive(:upload_pe_tarball)
-        expect(install.download_and_move_pe_tarball(TEST_HTTPS_URL, pe_tarball_filename, \
-                                                    target_master)).to eq(false)
+        expect(install.download_and_move_pe_tarball(pe_tarball_url)).to eq(false)
       end
     end
   end
 
   describe "#handle_tarball_url" do
-    context "when the target master is localhost" do
-      context "when the download is successful" do
-        it "returns the filename" do
-          master = "localhost"
+    context "when the url is successfully parsed" do
+      before do
+        install.instance_variable_set(:@pe_tarball_filename, pe_tarball_filename)
+      end
 
-          expect(URI).to receive(:parse).with(TEST_HTTPS_URL).and_return(test_uri)
-          expect(test_uri).to receive(:path)
-          expect(File).to receive(:basename).and_return(pe_tarball_filename)
-          expect(master).to receive(:equal?).with("localhost").and_return(true)
-          expect(install).to receive(:download_pe_tarball).with(TEST_HTTPS_URL, master)
-                                                          .and_return(true)
-          expect(install).not_to receive(:download_and_move_pe_tarball)
-          expect(install.handle_tarball_url(TEST_HTTPS_URL, master)).to eq(pe_tarball_filename)
+      context "when the target master is localhost" do
+        before do
+          install.instance_variable_set(:@target_master, target_master)
+        end
+
+        context "when the download is successful" do
+          it "returns the tarball path on the target master" do
+            # TODO: handle instance variable
+
+            expect(install).to receive(:parse_url).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:target_master_is_localhost?).and_return(true)
+            expect(install).to receive(:download_pe_tarball).with(pe_tarball_url, "localhost")
+                                                            .and_return(true)
+            expect(install).not_to receive(:download_and_move_pe_tarball)
+            expect(install.handle_tarball_url(pe_tarball_url)).to eq(tarball_path_on_master)
+          end
+        end
+
+        context "when the download is not successful" do
+          it "raises an error" do
+            expect(install).to receive(:parse_url).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:target_master_is_localhost?).and_return(true)
+            expect(install).to receive(:download_pe_tarball)
+              .with(pe_tarball_url, "localhost").and_return(false)
+            expect { install.handle_tarball_url(pe_tarball_url) }.to raise_error(RuntimeError)
+          end
         end
       end
 
-      context "when the download is not successful" do
-        it "raises an error" do
-          master = "localhost"
-          expect(URI).to receive(:parse).with(TEST_HTTPS_URL).and_return(test_uri)
-          expect(test_uri).to receive(:path)
-          expect(File).to receive(:basename).and_return(pe_tarball_filename)
-          expect(master).to receive(:equal?).with("localhost").and_return(true)
-          expect(install).to receive(:download_pe_tarball).with(TEST_HTTPS_URL, master)
-                                                          .and_return(false)
-          expect { install.handle_tarball_url(TEST_HTTPS_URL, master) }.to raise_error(RuntimeError)
+      context "when the target master is not localhost" do
+        before do
+          install.instance_variable_set(:@target_master, remote_target_master)
+        end
+
+        context "when the download is successful" do
+          it "doesn't attempt to move the tarball, returns the tarball path on the target master" do
+            expect(install).to receive(:parse_url).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:target_master_is_localhost?).and_return(false)
+            allow(install).to receive(:puts)
+
+            expect(install).to receive(:download_pe_tarball)
+              .with(pe_tarball_url, remote_target_master)
+              .and_return(true)
+
+            expect(install).not_to receive(:download_and_move_pe_tarball)
+
+            expect(install.handle_tarball_url(pe_tarball_url)).to eq(tarball_path_on_master)
+          end
+        end
+
+        context "when the download is not successful" do
+          context "when the subsequent download and move is successful" do
+            it "does not raise an error and returns the filename" do
+              expect(install).to receive(:parse_url).with(pe_tarball_url).and_return(true)
+              expect(install).to receive(:target_master_is_localhost?).and_return(false)
+
+              allow(install).to receive(:puts)
+
+              expect(install).to receive(:download_pe_tarball)
+                .with(pe_tarball_url, remote_target_master)
+                .and_return(false)
+
+              expect(install).to receive(:download_and_move_pe_tarball)
+                .with(pe_tarball_url)
+                .and_return(true)
+
+              expect(install.handle_tarball_url(pe_tarball_url))
+                .to eq(tarball_path_on_master)
+            end
+          end
+
+          context "when the subsequent download and move is not successful" do
+            it "raises an error" do
+              expect(install).to receive(:parse_url).with(pe_tarball_url).and_return(true)
+              expect(install).to receive(:target_master_is_localhost?).and_return(false)
+
+              allow(install).to receive(:puts)
+
+              expect(install).to receive(:download_pe_tarball)
+                .with(pe_tarball_url, remote_target_master)
+                .and_return(false)
+
+              expect(install).to receive(:download_and_move_pe_tarball)
+                .with(pe_tarball_url)
+                .and_return(false)
+
+              expect { install.handle_tarball_url(pe_tarball_url) }
+                .to raise_error(RuntimeError)
+            end
+          end
         end
       end
     end
 
-    context "when the target master is not localhost" do
-      context "when the download is successful" do
-        it "does not attempt to move the tarball and returns the filename" do
-          expect(URI).to receive(:parse).with(TEST_HTTPS_URL).and_return(test_uri)
-          expect(test_uri).to receive(:path)
-          expect(File).to receive(:basename).and_return(pe_tarball_filename)
-          expect(target_master).to receive(:equal?).with("localhost").and_return(false)
+    context "when the url is not successfully parsed" do
+      it "raises an error" do
+        expect(install).to receive(:parse_url).with("http:// 123").and_raise(RuntimeError)
 
-          allow(install).to receive(:puts)
-          expect(install).to receive(:puts)
-            .with("Specified target master #{target_master} is not localhost")
-
-          expect(install).to receive(:download_pe_tarball)
-            .with(TEST_HTTPS_URL, target_master)
-            .and_return(true)
-          expect(install).not_to receive(:download_and_move_pe_tarball)
-          expect(install.handle_tarball_url(TEST_HTTPS_URL, target_master))
-            .to eq(pe_tarball_filename)
-        end
-      end
-
-      context "when the download is not successful" do
-        context "when the subsequent download and move is successful" do
-          it "does not raise an error and returns the filename" do
-            expect(URI).to receive(:parse).with(TEST_HTTPS_URL).and_return(test_uri)
-            expect(test_uri).to receive(:path)
-            expect(File).to receive(:basename).and_return(pe_tarball_filename)
-            expect(target_master).to receive(:equal?).with("localhost").and_return(false)
-
-            allow(install).to receive(:puts)
-            expect(install).to receive(:puts)
-              .with("Specified target master #{target_master} is not localhost")
-
-            expect(install).to receive(:download_pe_tarball)
-              .with(TEST_HTTPS_URL, target_master)
-              .and_return(false)
-
-            expect(install).to receive(:download_and_move_pe_tarball)
-              .with(TEST_HTTPS_URL, pe_tarball_filename, target_master)
-              .and_return(true)
-
-            expect(install.handle_tarball_url(TEST_HTTPS_URL, target_master))
-              .to eq(pe_tarball_filename)
-          end
-        end
-
-        context "when the subsequent download and move is not successful" do
-          it "raises an error" do
-            expect(URI).to receive(:parse).with(TEST_HTTPS_URL).and_return(test_uri)
-            expect(test_uri).to receive(:path)
-            expect(File).to receive(:basename).and_return(pe_tarball_filename)
-            expect(target_master).to receive(:equal?).with("localhost").and_return(false)
-
-            allow(install).to receive(:puts)
-            expect(install).to receive(:puts)
-              .with("Specified target master #{target_master} is not localhost")
-
-            expect(install).to receive(:download_pe_tarball)
-              .with(TEST_HTTPS_URL, target_master)
-              .and_return(false)
-
-            expect(install).to receive(:download_and_move_pe_tarball)
-              .with(TEST_HTTPS_URL, pe_tarball_filename, target_master)
-              .and_return(false)
-
-            expect { install.handle_tarball_url(TEST_HTTPS_URL, target_master) }
-              .to raise_error(RuntimeError)
-          end
-        end
+        expect { install.handle_tarball_url("http:// 123") }
+          .to raise_error(RuntimeError)
       end
     end
   end
 
   describe "#copy_pe_tarball" do
     before do
-      @command = "cp #{pe_tarball_path} #{master_tarball_path}"
+      @command = "cp #{pe_tarball} #{tmp_work_dir}"
     end
 
     context "when the file is copied successfully" do
       it "returns true" do
-        expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
         expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)
           .with(@command, target_master)
           .and_return(true)
-        expect(install.copy_pe_tarball(pe_tarball_path, target_master)).to eq(true)
+        expect(install.copy_pe_tarball_on_target_master(pe_tarball)).to eq(true)
       end
     end
 
     context "when the file is not copied successfully" do
       it "returns false" do
-        expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
         expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)
           .with(@command, target_master)
           .and_return(false)
-        expect(install.copy_pe_tarball(pe_tarball_path, target_master)).to eq(false)
+        expect(install.copy_pe_tarball_on_target_master(pe_tarball)).to eq(false)
       end
     end
   end
 
   describe "#handle_tarball_with_remote_target_master" do
     before do
+      install.instance_variable_set(:@target_master, remote_target_master)
       @remote_flag = "#{remote_target_master}:"
-      @remote_tarball_path = @remote_flag + pe_tarball_path
+      @remote_tarball_path = @remote_flag + pe_tarball
     end
     context "when the tarball path is on the master" do
       context "when the file exists" do
         it "copies the file to the tmp working dir and returns true" do
-          expect(@remote_tarball_path).to receive(:start_with?).with(@remote_flag)
-                                                               .and_return(true)
+          expect(@remote_tarball_path).to receive(:start_with?).with(@remote_flag).and_return(true)
 
-          expect(@remote_tarball_path).to receive(:sub!).with(@remote_flag, "")
-                                                        .and_return(pe_tarball_path)
+          expect(@remote_tarball_path).to receive(:sub!)
+            .with(@remote_flag, "").and_return(pe_tarball)
 
           expect(install).to receive(:file_exist_on_target_master?)
-            .with(pe_tarball_path, remote_target_master).and_return(true)
+            .with(pe_tarball).and_return(true)
 
-          expect(install).to receive(:copy_pe_tarball)
-            .with(pe_tarball_path, remote_target_master).and_return(true)
+          expect(install).to receive(:copy_pe_tarball_on_target_master)
+            .with(pe_tarball).and_return(true)
 
-          expect(install.handle_tarball_with_remote_target_master(@remote_tarball_path, \
-                                                                  remote_target_master)).to eq(true)
+          expect(install.handle_tarball_path_with_remote_target_master(@remote_tarball_path))
+            .to eq(true)
         end
       end
 
@@ -472,16 +569,15 @@ describe RefArchSetup::Install do
                                                                .and_return(true)
 
           expect(@remote_tarball_path).to receive(:sub!).with(@remote_flag, "")
-                                                        .and_return(pe_tarball_path)
+                                                        .and_return(pe_tarball)
 
           expect(install).to receive(:file_exist_on_target_master?)
-            .with(pe_tarball_path, remote_target_master).and_return(false)
+            .with(pe_tarball).and_return(false)
 
-          expect(install).not_to receive(:copy_pe_tarball)
+          expect(install).not_to receive(:copy_pe_tarball_on_target_master)
 
           # TODO: rubocop Metrics/LineLength?
-          expect(install.handle_tarball_with_remote_target_master(@remote_tarball_path, \
-                                                                  remote_target_master))
+          expect(install.handle_tarball_path_with_remote_target_master(@remote_tarball_path))
             .to eq(false)
         end
       end
@@ -490,36 +586,34 @@ describe RefArchSetup::Install do
     context "when the tarball path is not on the master" do
       context "when the file exists" do
         it "uploads the file to the tmp working dir and returns true" do
-          expect(pe_tarball_path).to receive(:start_with?).with(@remote_flag)
-                                                          .and_return(false)
+          expect(pe_tarball).to receive(:start_with?).with(@remote_flag)
+                                                     .and_return(false)
 
           expect(install).not_to receive(:file_exist_on_target_master?)
-          expect(install).not_to receive(:copy_pe_tarball)
+          expect(install).not_to receive(:copy_pe_tarball_on_target_master)
 
-          expect(File).to receive(:exist?).with(pe_tarball_path).and_return(true)
+          expect(File).to receive(:exist?).with(pe_tarball).and_return(true)
           expect(install).to receive(:upload_pe_tarball)
-            .with(pe_tarball_path).and_return(true)
+            .with(pe_tarball).and_return(true)
 
-          expect(install.handle_tarball_with_remote_target_master(pe_tarball_path, \
-                                                                  remote_target_master)).to eq(true)
+          expect(install.handle_tarball_path_with_remote_target_master(pe_tarball))
+            .to eq(true)
         end
       end
 
       context "when the file does not exist" do
         it "does not upload the file and returns false" do
-          expect(pe_tarball_path).to receive(:start_with?).with(@remote_flag)
-                                                          .and_return(false)
+          expect(pe_tarball).to receive(:start_with?)
+            .with(@remote_flag).and_return(false)
 
           expect(install).not_to receive(:file_exist_on_target_master?)
-          expect(install).not_to receive(:copy_pe_tarball)
+          expect(install).not_to receive(:copy_pe_tarball_on_target_master)
 
-          expect(File).to receive(:exist?).with(pe_tarball_path).and_return(true)
+          expect(File).to receive(:exist?).with(pe_tarball).and_return(true)
           expect(install).to receive(:upload_pe_tarball)
-            .with(pe_tarball_path).and_return(false)
+            .with(pe_tarball).and_return(false)
 
-          # TODO: rubocop Metrics/LineLength?
-          expect(install.handle_tarball_with_remote_target_master(pe_tarball_path, \
-                                                                  remote_target_master))
+          expect(install.handle_tarball_path_with_remote_target_master(pe_tarball))
             .to eq(false)
         end
       end
@@ -528,29 +622,32 @@ describe RefArchSetup::Install do
 
   describe "#handle_tarball_path" do
     context "when the target master is localhost" do
+      before do
+        install.instance_variable_set(:@target_master, target_master)
+      end
+
       context "when the tarball exists" do
         context "when the upload is successful" do
           it "returns the filename" do
-            master = "localhost"
-            expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
-            expect(master).to receive(:equal?).with("localhost").and_return(true)
-            expect(File).to receive(:exist?).with(pe_tarball_path).and_return(true)
+            expect(File).to receive(:basename).with(pe_tarball).and_return(pe_tarball_filename)
+            expect(install).to receive(:target_master_is_localhost?).and_return(true)
+
+            expect(File).to receive(:exist?).with(pe_tarball).and_return(true)
             expect(install).to receive(:upload_pe_tarball)
-              .with(pe_tarball_path).and_return(true)
-            expect(install.handle_tarball_path(pe_tarball_path, master)).to eq(pe_tarball_filename)
+              .with(pe_tarball).and_return(true)
+            expect(install.handle_tarball_path(pe_tarball)).to eq(tarball_path_on_master)
           end
         end
 
         context "when the upload is not successful" do
           it "raises an error" do
-            master = "localhost"
-            expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
-            expect(master).to receive(:equal?).with("localhost").and_return(true)
-            expect(File).to receive(:exist?).with(pe_tarball_path).and_return(true)
+            expect(File).to receive(:basename).with(pe_tarball).and_return(pe_tarball_filename)
+            expect(install).to receive(:target_master_is_localhost?).and_return(true)
+            expect(File).to receive(:exist?).with(pe_tarball).and_return(true)
             expect(install).to receive(:upload_pe_tarball)
-              .with(pe_tarball_path).and_return(false)
+              .with(pe_tarball).and_return(false)
 
-            expect { install.handle_tarball_path(pe_tarball_path, master) }
+            expect { install.handle_tarball_path(pe_tarball) }
               .to raise_error(RuntimeError)
           end
         end
@@ -558,40 +655,43 @@ describe RefArchSetup::Install do
 
       context "when the tarball does not exist" do
         it "raises an error" do
-          master = "localhost"
-          expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
-          expect(master).to receive(:equal?).with("localhost").and_return(true)
-          expect(File).to receive(:exist?).with(pe_tarball_path).and_return(false)
+          expect(File).to receive(:basename).with(pe_tarball).and_return(pe_tarball_filename)
+          expect(install).to receive(:target_master_is_localhost?).and_return(true)
+          expect(File).to receive(:exist?).with(pe_tarball).and_return(false)
           expect(install).not_to receive(:upload_pe_tarball)
-          expect { install.handle_tarball_path(pe_tarball_path, master) }
+          expect { install.handle_tarball_path(pe_tarball) }
             .to raise_error(RuntimeError)
         end
       end
     end
 
     context "when the target master is not localhost" do
+      before do
+        install.instance_variable_set(:@target_master, remote_target_master)
+      end
+
       context "when the tarball is handled successfully" do
         it "returns the filename" do
-          expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
-          expect(remote_target_master).to receive(:equal?).with("localhost").and_return(false)
+          expect(File).to receive(:basename).with(pe_tarball).and_return(pe_tarball_filename)
+          expect(install).to receive(:target_master_is_localhost?).and_return(false)
 
-          expect(install).to receive(:handle_tarball_with_remote_target_master)
-            .with(pe_tarball_path, remote_target_master).and_return(true)
+          expect(install).to receive(:handle_tarball_path_with_remote_target_master)
+            .with(pe_tarball).and_return(true)
 
-          expect(install.handle_tarball_path(pe_tarball_path, remote_target_master))
-            .to eq(pe_tarball_filename)
+          expect(install.handle_tarball_path(pe_tarball))
+            .to eq(tarball_path_on_master)
         end
       end
 
       context "when the tarball is not handled successfully" do
         it "raises an error" do
-          expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
-          expect(remote_target_master).to receive(:equal?).with("localhost").and_return(false)
+          expect(File).to receive(:basename).with(pe_tarball).and_return(pe_tarball_filename)
+          expect(install).to receive(:target_master_is_localhost?).and_return(false)
 
-          expect(install).to receive(:handle_tarball_with_remote_target_master)
-            .with(pe_tarball_path, remote_target_master).and_return(false)
+          expect(install).to receive(:handle_tarball_path_with_remote_target_master)
+            .with(pe_tarball).and_return(false)
 
-          expect { install.handle_tarball_path(pe_tarball_path, remote_target_master) }
+          expect { install.handle_tarball_path(pe_tarball) }
             .to raise_error(RuntimeError)
         end
       end
@@ -603,24 +703,23 @@ describe RefArchSetup::Install do
       context "when the tarball path is a valid URL" do
         context "when the tarball URL is handled successfully" do
           it "returns the tarball path on the master" do
-            expect(install).to receive(:valid_extension?).with(pe_tarball_url).and_return(true)
-            expect(install).to receive(:valid_tarball_url?).with(pe_tarball_url).and_return(true)
-            expect(install).to receive(:handle_tarball_url).with(pe_tarball_url, target_master)
-                                                           .and_return(pe_tarball_filename)
+            # expect(install).to receive(:validate_extension).with(pe_tarball_url)
+            expect(install).to receive(:valid_url?).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:handle_tarball_url)
+              .with(pe_tarball_url).and_return(tarball_path_on_master)
 
-            expect(install.handle_pe_tarball(pe_tarball_url, target_master))
-              .to eq(master_tarball_path)
+            expect(install.handle_pe_tarball(pe_tarball_url))
+              .to eq(tarball_path_on_master)
           end
         end
 
         context "when the tarball URL is not handled successfully" do
           it "raises an error" do
-            expect(install).to receive(:valid_extension?).with(pe_tarball_url).and_return(true)
-            expect(install).to receive(:valid_tarball_url?).with(pe_tarball_url).and_return(true)
-            expect(install).to receive(:handle_tarball_url).with(pe_tarball_url, target_master)
-                                                           .and_return(nil)
+            # expect(install).to receive(:validate_extension).with(pe_tarball_url)
+            expect(install).to receive(:valid_url?).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:handle_tarball_url).with(pe_tarball_url).and_return(nil)
 
-            expect { install.handle_pe_tarball(pe_tarball_url, target_master) }
+            expect { install.handle_pe_tarball(pe_tarball_url) }
               .to raise_error(RuntimeError)
           end
         end
@@ -629,24 +728,23 @@ describe RefArchSetup::Install do
       context "when the tarball path is not a valid URL and a path is assumed" do
         context "when the tarball path is handled successfully" do
           it "returns the tarball path on the master" do
-            expect(install).to receive(:valid_extension?).with(pe_tarball_path).and_return(true)
-            expect(install).to receive(:valid_tarball_url?).with(pe_tarball_path).and_return(false)
-            expect(install).to receive(:handle_tarball_path).with(pe_tarball_path, target_master)
-                                                            .and_return(pe_tarball_filename)
+            # expect(install).to receive(:validate_extension).with(pe_tarball)
+            expect(install).to receive(:valid_url?).with(pe_tarball).and_return(false)
+            expect(install).to receive(:handle_tarball_path)
+              .with(pe_tarball).and_return(tarball_path_on_master)
 
-            expect(install.handle_pe_tarball(pe_tarball_path, target_master))
-              .to eq(master_tarball_path)
+            expect(install.handle_pe_tarball(pe_tarball))
+              .to eq(tarball_path_on_master)
           end
         end
 
         context "when the tarball path is not handled successfully" do
           it "raises an error" do
-            expect(install).to receive(:valid_extension?).with(pe_tarball_path).and_return(true)
-            expect(install).to receive(:valid_tarball_url?).with(pe_tarball_path).and_return(false)
-            expect(install).to receive(:handle_tarball_path).with(pe_tarball_path, target_master)
-                                                            .and_return(nil)
+            # expect(install).to receive(:validate_extension).with(pe_tarball)
+            expect(install).to receive(:valid_url?).with(pe_tarball).and_return(false)
+            expect(install).to receive(:handle_tarball_path).with(pe_tarball).and_return(nil)
 
-            expect { install.handle_pe_tarball(pe_tarball_path, target_master) }
+            expect { install.handle_pe_tarball(pe_tarball) }
               .to raise_error(RuntimeError)
           end
         end
@@ -656,8 +754,8 @@ describe RefArchSetup::Install do
     context "when the extension is not valid" do
       it "raises an error" do
         path = "invalid"
-        expect(install).to receive(:valid_extension?).with(path).and_return(false)
-        expect { install.handle_pe_tarball(path, target_master) }
+        # expect(install).to receive(:validate_extension).with(path)
+        expect { install.handle_pe_tarball(path) }
           .to raise_error(RuntimeError)
       end
     end
@@ -676,7 +774,7 @@ describe RefArchSetup::Install do
       it "returns true" do
         expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
           .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(true)
-        expect(install.make_tmp_work_dir(target_master)).to eq(true)
+        expect(install.make_tmp_work_dir).to eq(true)
       end
     end
 
@@ -684,7 +782,7 @@ describe RefArchSetup::Install do
       it "returns false" do
         expect(RefArchSetup::BoltHelper).to receive(:make_dir)\
           .with(RefArchSetup::TMP_WORK_DIR, target_master).and_return(false)
-        expect(install.make_tmp_work_dir(target_master)).to eq(false)
+        expect(install.make_tmp_work_dir).to eq(false)
       end
     end
   end
@@ -726,6 +824,8 @@ describe RefArchSetup::Install do
       it "returns true" do
         src = "/tmp/foo.tar"
         dest = "#{RefArchSetup::TMP_WORK_DIR}/foo.tar"
+        message = "Attempting upload from #{src} to #{dest} on #{target_master}"
+        expect(install).to receive(:puts).with(message)
         expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
           .with(src, dest, target_master).and_return(true)
         expect(install.upload_pe_tarball(src)).to eq(true)
@@ -736,9 +836,11 @@ describe RefArchSetup::Install do
       it "returns true" do
         src = "/tmp/foo.tar"
         dest = "/tmp/foo"
+        message = "Attempting upload from #{src} to #{dest} on #{target_master}"
+        expect(install).to receive(:puts).with(message)
         expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
           .with(src, dest, target_master).and_return(true)
-        expect(install.upload_pe_tarball(src, dest, target_master)).to eq(true)
+        expect(install.upload_pe_tarball(src, dest)).to eq(true)
       end
     end
 
@@ -746,9 +848,11 @@ describe RefArchSetup::Install do
       it "returns false" do
         src = "/tmp/foo.tar"
         dest = "/tmp/foo"
+        message = "Attempting upload from #{src} to #{dest} on #{target_master}"
+        expect(install).to receive(:puts).with(message)
         expect(RefArchSetup::BoltHelper).to receive(:upload_file)\
           .with(src, dest, target_master).and_return(false)
-        expect(install.upload_pe_tarball(src, dest, target_master)).to eq(false)
+        expect(install.upload_pe_tarball(src, dest)).to eq(false)
       end
     end
   end

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -1,19 +1,36 @@
 require "spec_helper"
 
 describe RefArchSetup::Install do
-  let(:target_master)   { "local://localhost" }
-  let(:pe_conf_path)    { "/tmp/pe.conf" }
-  let(:pe_tarball_path) { "/tmp/pe.tarball" }
-  let(:install)         { RefArchSetup::Install.new(target_master) }
-  let(:task)            { "ref_arch_setup::install_pe" }
-  let(:params)          do
-    { "pe_conf_path" => pe_conf_path, "pe_tarball_path" => pe_tarball_path, \
-      "pe_target_master" => target_master }
+  let(:target_master) { "local://localhost" }
+  let(:remote_target_master) { "remote.target.master" }
+  let(:pe_conf_path) { "/tmp/pe.conf" }
+  let(:pe_tarball_filename) { "pe.tarball.tar.gz" }
+  let(:pe_tarball_path) { "/tmp/#{pe_tarball_filename}" }
+  let(:master_tarball_path) { "/tmp/ref_arch_setup/#{pe_tarball_filename}" }
+  let(:install) { RefArchSetup::Install.new(target_master) }
+  let(:install_task) { "ref_arch_setup::install_pe" }
+  let(:install_task_params) do
+    { "pe_conf_path" => pe_conf_path, "pe_tarball_path" => master_tarball_path }
   end
-  let(:params_str) do
-    "pe_conf_path=#{pe_tarball_path} pe_tarball_path=#{pe_tarball_path} " \
-      "pe_target_master=#{target_master}"
+
+  # TODO: remove?
+  # let(:params_str) do
+  #   "pe_conf_path=#{pe_tarball_path} pe_tarball_path=#{pe_tarball_path} " \
+  #     "pe_target_master=#{target_master}"
+  # end
+
+  let(:pe_tarball_url) { "https://test.net/2018.1/pe.tar.gz" }
+  let(:tmp_work_dir) { "/tmp/ref_arch_setup" }
+  let(:download_task) { "ref_arch_setup::download_pe_tarball" }
+  let(:download_task_params) do
+    { "url" => pe_tarball_url, "destination" => tmp_work_dir }
   end
+
+  let(:test_uri) { Class.new }
+
+  TEST_HTTP_URL = "http://test.net/2018.1/pe.tar.gz".freeze
+  TEST_HTTPS_URL = "https://test.net/2018.1/pe.tar.gz".freeze
+  # TEST_MASTER_TARBALL_PATH = "/tmp/ref_arch_setup/pe.tarball.tar.gz".freeze
 
   describe "initialize" do
     it "checks that the passed in parameters get used" do
@@ -23,12 +40,13 @@ describe RefArchSetup::Install do
   end
 
   describe "bootstrap" do
-    before do
-      @expected_command = "bolt task run #{task} "
-      @expected_command << params_str
-      @expected_command << " --modulepath #{RefArchSetup::RAS_MODULE_PATH}"
-      @expected_command << " --nodes #{target_master}"
-    end
+    # TODO: remove?
+    # before do
+    #   @expected_command = "bolt task run #{install_task} "
+    #   @expected_command << params_str
+    #   @expected_command << " --modulepath #{RefArchSetup::RAS_MODULE_PATH}"
+    #   @expected_command << " --nodes #{target_master}"
+    # end
 
     context "when make_temp_dir and handle_pe_conf do not raise errors" do
       context "when called using default value" do
@@ -36,8 +54,9 @@ describe RefArchSetup::Install do
           it "returns true" do
             expect(install).to receive(:make_tmp_work_dir).and_return(true)
             expect(install).to receive(:handle_pe_conf).and_return(true)
+            expect(install).to receive(:handle_pe_tarball).and_return(master_tarball_path)
             expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
-              .with(task, params, target_master)
+              .with(install_task, install_task_params, target_master)
               .and_return(true)
             expect(install.bootstrap(pe_conf_path, pe_tarball_path)).to eq(true)
           end
@@ -49,8 +68,9 @@ describe RefArchSetup::Install do
           it "returns true" do
             expect(install).to receive(:make_tmp_work_dir).and_return(true)
             expect(install).to receive(:handle_pe_conf).and_return(true)
+            expect(install).to receive(:handle_pe_tarball).and_return(master_tarball_path)
             expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
-              .with(task, params, target_master).and_return(true)
+              .with(install_task, install_task_params, target_master).and_return(true)
             expect(install.bootstrap(pe_conf_path, pe_tarball_path, target_master)).to eq(true)
           end
         end
@@ -59,8 +79,9 @@ describe RefArchSetup::Install do
           it "returns false" do
             expect(install).to receive(:make_tmp_work_dir).and_return(true)
             expect(install).to receive(:handle_pe_conf).and_return(true)
+            expect(install).to receive(:handle_pe_tarball).and_return(master_tarball_path)
             expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
-              .with(task, params, target_master).and_return(false)
+              .with(install_task, install_task_params, target_master).and_return(false)
             expect(install.bootstrap(pe_conf_path, pe_tarball_path, target_master)).to eq(false)
           end
         end
@@ -154,6 +175,482 @@ describe RefArchSetup::Install do
           expect { install.handle_pe_conf(file_path) }.to \
             raise_error(RuntimeError, /pe.conf file not found #{file_path}/)
         end
+      end
+    end
+  end
+
+  # TODO: mock URI?
+  describe "#valid_tarball_url?" do
+    context "when given a url starting with http" do
+      it "returns true" do
+        expect(install.valid_tarball_url?(TEST_HTTP_URL)).to eq(true)
+      end
+    end
+
+    context "when given a url starting with https" do
+      it "returns true" do
+        expect(install.valid_tarball_url?(TEST_HTTPS_URL)).to eq(true)
+      end
+    end
+
+    context "when given an invalid url" do
+      it "returns false" do
+        expect(install.valid_tarball_url?(pe_tarball_path)).to eq(false)
+      end
+    end
+  end
+
+  describe "#valid_extension??" do
+    context "when given a path ending with .tar.gz" do
+      it "returns true" do
+        expect(install.valid_extension?(pe_tarball_path)).to eq(true)
+      end
+    end
+
+    context "when given a url ending with .tar.gz" do
+      it "returns true" do
+        expect(install.valid_extension?(TEST_HTTPS_URL)).to eq(true)
+      end
+    end
+
+    context "when given a path not ending in .tar.gz" do
+      it "reports the error and returns false" do
+        path = "/tmp/file.txt"
+        message1 = "Invalid extension for tarball: #{path}."
+        message2 = "Extension must be .tar.gz"
+
+        allow(install).to receive(:puts)
+        expect(install).to receive(:puts).with(message1)
+        expect(install).to receive(:puts).with(message2)
+        expect(install.valid_extension?(path)).to eq(false)
+      end
+    end
+  end
+
+  describe "#file_exist_on_target_master??" do
+    before do
+      @command = "[ -f #{pe_tarball_path} ]"
+    end
+
+    context "when the file exists on the target master" do
+      it "returns true" do
+        expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)
+          .with(@command, target_master)
+          .and_return(true)
+        expect(install.file_exist_on_target_master?(pe_tarball_path, target_master)).to eq(true)
+      end
+    end
+
+    context "when the file does not exist on the target master" do
+      it "returns false" do
+        expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)
+          .with(@command, target_master)
+          .and_return(false)
+        expect(install.file_exist_on_target_master?(pe_tarball_path, target_master)).to eq(false)
+      end
+    end
+  end
+
+  describe "#download_pe_tarball??" do
+    context "when the download is successful" do
+      it "returns true" do
+        allow(install).to receive(:puts)
+        expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
+          .with(download_task, download_task_params, target_master).and_return(true)
+        expect(install.download_pe_tarball(TEST_HTTPS_URL, target_master)).to eq(true)
+      end
+    end
+
+    context "when the download is not successful" do
+      it "returns false" do
+        allow(install).to receive(:puts)
+        expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
+          .with(download_task, download_task_params, target_master).and_return(false)
+        expect(install.download_pe_tarball(TEST_HTTPS_URL, target_master)).to eq(false)
+      end
+    end
+  end
+
+  describe "#download_and_move_pe_tarball" do
+    context "when the download is successful" do
+      context "when the upload is successful" do
+        it "returns true" do
+          allow(install).to receive(:puts)
+          expect(install).to receive(:download_pe_tarball).with(TEST_HTTPS_URL, "localhost")
+                                                          .and_return(true)
+          expect(install).to receive(:upload_pe_tarball).with(master_tarball_path, target_master)
+                                                        .and_return(true)
+          expect(install.download_and_move_pe_tarball(TEST_HTTPS_URL, pe_tarball_filename, \
+                                                      target_master)).to eq(true)
+        end
+      end
+
+      context "when the upload is not successful" do
+        it "returns false" do
+          allow(install).to receive(:puts)
+          expect(install).to receive(:download_pe_tarball).with(TEST_HTTPS_URL, "localhost")
+                                                          .and_return(true)
+          expect(install).to receive(:upload_pe_tarball).with(master_tarball_path, target_master)
+                                                        .and_return(false)
+          expect(install.download_and_move_pe_tarball(TEST_HTTPS_URL, pe_tarball_filename, \
+                                                      target_master))
+            .to eq(false)
+        end
+      end
+    end
+
+    context "when the download is not successful" do
+      it "does not attempt to upload and returns false" do
+        allow(install).to receive(:puts)
+        expect(install).to receive(:download_pe_tarball).with(TEST_HTTPS_URL, "localhost")
+                                                        .and_return(false)
+        expect(install).not_to receive(:upload_pe_tarball)
+        expect(install.download_and_move_pe_tarball(TEST_HTTPS_URL, pe_tarball_filename, \
+                                                    target_master)).to eq(false)
+      end
+    end
+  end
+
+  describe "#handle_tarball_url" do
+    context "when the target master is localhost" do
+      context "when the download is successful" do
+        it "returns the filename" do
+          master = "localhost"
+
+          expect(URI).to receive(:parse).with(TEST_HTTPS_URL).and_return(test_uri)
+          expect(test_uri).to receive(:path)
+          expect(File).to receive(:basename).and_return(pe_tarball_filename)
+          expect(master).to receive(:equal?).with("localhost").and_return(true)
+          expect(install).to receive(:download_pe_tarball).with(TEST_HTTPS_URL, master)
+                                                          .and_return(true)
+          expect(install).not_to receive(:download_and_move_pe_tarball)
+          expect(install.handle_tarball_url(TEST_HTTPS_URL, master)).to eq(pe_tarball_filename)
+        end
+      end
+
+      context "when the download is not successful" do
+        it "raises an error" do
+          master = "localhost"
+          expect(URI).to receive(:parse).with(TEST_HTTPS_URL).and_return(test_uri)
+          expect(test_uri).to receive(:path)
+          expect(File).to receive(:basename).and_return(pe_tarball_filename)
+          expect(master).to receive(:equal?).with("localhost").and_return(true)
+          expect(install).to receive(:download_pe_tarball).with(TEST_HTTPS_URL, master)
+                                                          .and_return(false)
+          expect { install.handle_tarball_url(TEST_HTTPS_URL, master) }.to raise_error(RuntimeError)
+        end
+      end
+    end
+
+    context "when the target master is not localhost" do
+      context "when the download is successful" do
+        it "does not attempt to move the tarball and returns the filename" do
+          expect(URI).to receive(:parse).with(TEST_HTTPS_URL).and_return(test_uri)
+          expect(test_uri).to receive(:path)
+          expect(File).to receive(:basename).and_return(pe_tarball_filename)
+          expect(target_master).to receive(:equal?).with("localhost").and_return(false)
+
+          allow(install).to receive(:puts)
+          expect(install).to receive(:puts)
+            .with("Specified target master #{target_master} is not localhost")
+
+          expect(install).to receive(:download_pe_tarball)
+            .with(TEST_HTTPS_URL, target_master)
+            .and_return(true)
+          expect(install).not_to receive(:download_and_move_pe_tarball)
+          expect(install.handle_tarball_url(TEST_HTTPS_URL, target_master))
+            .to eq(pe_tarball_filename)
+        end
+      end
+
+      context "when the download is not successful" do
+        context "when the subsequent download and move is successful" do
+          it "does not raise an error and returns the filename" do
+            expect(URI).to receive(:parse).with(TEST_HTTPS_URL).and_return(test_uri)
+            expect(test_uri).to receive(:path)
+            expect(File).to receive(:basename).and_return(pe_tarball_filename)
+            expect(target_master).to receive(:equal?).with("localhost").and_return(false)
+
+            allow(install).to receive(:puts)
+            expect(install).to receive(:puts)
+              .with("Specified target master #{target_master} is not localhost")
+
+            expect(install).to receive(:download_pe_tarball)
+              .with(TEST_HTTPS_URL, target_master)
+              .and_return(false)
+
+            expect(install).to receive(:download_and_move_pe_tarball)
+              .with(TEST_HTTPS_URL, pe_tarball_filename, target_master)
+              .and_return(true)
+
+            expect(install.handle_tarball_url(TEST_HTTPS_URL, target_master))
+              .to eq(pe_tarball_filename)
+          end
+        end
+
+        context "when the subsequent download and move is not successful" do
+          it "raises an error" do
+            expect(URI).to receive(:parse).with(TEST_HTTPS_URL).and_return(test_uri)
+            expect(test_uri).to receive(:path)
+            expect(File).to receive(:basename).and_return(pe_tarball_filename)
+            expect(target_master).to receive(:equal?).with("localhost").and_return(false)
+
+            allow(install).to receive(:puts)
+            expect(install).to receive(:puts)
+              .with("Specified target master #{target_master} is not localhost")
+
+            expect(install).to receive(:download_pe_tarball)
+              .with(TEST_HTTPS_URL, target_master)
+              .and_return(false)
+
+            expect(install).to receive(:download_and_move_pe_tarball)
+              .with(TEST_HTTPS_URL, pe_tarball_filename, target_master)
+              .and_return(false)
+
+            expect { install.handle_tarball_url(TEST_HTTPS_URL, target_master) }
+              .to raise_error(RuntimeError)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#copy_pe_tarball" do
+    before do
+      @command = "cp #{pe_tarball_path} #{master_tarball_path}"
+    end
+
+    context "when the file is copied successfully" do
+      it "returns true" do
+        expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
+        expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)
+          .with(@command, target_master)
+          .and_return(true)
+        expect(install.copy_pe_tarball(pe_tarball_path, target_master)).to eq(true)
+      end
+    end
+
+    context "when the file is not copied successfully" do
+      it "returns false" do
+        expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
+        expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)
+          .with(@command, target_master)
+          .and_return(false)
+        expect(install.copy_pe_tarball(pe_tarball_path, target_master)).to eq(false)
+      end
+    end
+  end
+
+  describe "#handle_tarball_with_remote_target_master" do
+    before do
+      @remote_flag = "#{remote_target_master}:"
+      @remote_tarball_path = @remote_flag + pe_tarball_path
+    end
+    context "when the tarball path is on the master" do
+      context "when the file exists" do
+        it "copies the file to the tmp working dir and returns true" do
+          expect(@remote_tarball_path).to receive(:start_with?).with(@remote_flag)
+                                                               .and_return(true)
+
+          expect(@remote_tarball_path).to receive(:sub!).with(@remote_flag, "")
+                                                        .and_return(pe_tarball_path)
+
+          expect(install).to receive(:file_exist_on_target_master?)
+            .with(pe_tarball_path, remote_target_master).and_return(true)
+
+          expect(install).to receive(:copy_pe_tarball)
+            .with(pe_tarball_path, remote_target_master).and_return(true)
+
+          expect(install.handle_tarball_with_remote_target_master(@remote_tarball_path, \
+                                                                  remote_target_master)).to eq(true)
+        end
+      end
+
+      context "when the file does not exist" do
+        it "does not copy the file and returns false" do
+          expect(@remote_tarball_path).to receive(:start_with?).with(@remote_flag)
+                                                               .and_return(true)
+
+          expect(@remote_tarball_path).to receive(:sub!).with(@remote_flag, "")
+                                                        .and_return(pe_tarball_path)
+
+          expect(install).to receive(:file_exist_on_target_master?)
+            .with(pe_tarball_path, remote_target_master).and_return(false)
+
+          expect(install).not_to receive(:copy_pe_tarball)
+          expect(install.handle_tarball_with_remote_target_master(@remote_tarball_path, \
+                                                                  remote_target_master)).to eq(false)
+        end
+      end
+    end
+
+    context "when the tarball path is not on the master" do
+      context "when the file exists" do
+        it "uploads the file to the tmp working dir and returns true" do
+          expect(pe_tarball_path).to receive(:start_with?).with(@remote_flag)
+                                                          .and_return(false)
+
+          expect(install).not_to receive(:file_exist_on_target_master?)
+          expect(install).not_to receive(:copy_pe_tarball)
+
+          expect(File).to receive(:exist?).with(pe_tarball_path).and_return(true)
+          expect(install).to receive(:upload_pe_tarball)
+            .with(pe_tarball_path).and_return(true)
+
+          expect(install.handle_tarball_with_remote_target_master(pe_tarball_path, \
+                                                                  remote_target_master)).to eq(true)
+        end
+      end
+
+      context "when the file does not exist" do
+        it "does not upload the file and returns false" do
+          expect(pe_tarball_path).to receive(:start_with?).with(@remote_flag)
+                                                          .and_return(false)
+
+          expect(install).not_to receive(:file_exist_on_target_master?)
+          expect(install).not_to receive(:copy_pe_tarball)
+
+          expect(File).to receive(:exist?).with(pe_tarball_path).and_return(true)
+          expect(install).to receive(:upload_pe_tarball)
+            .with(pe_tarball_path).and_return(false)
+
+          expect(install.handle_tarball_with_remote_target_master(pe_tarball_path, \
+                                                                  remote_target_master)).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "#handle_tarball_path" do
+    context "when the target master is localhost" do
+      context "when the tarball exists" do
+        context "when the upload is successful" do
+          it "returns the filename" do
+            master = "localhost"
+            expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
+            expect(master).to receive(:equal?).with("localhost").and_return(true)
+            expect(File).to receive(:exist?).with(pe_tarball_path).and_return(true)
+            expect(install).to receive(:upload_pe_tarball)
+              .with(pe_tarball_path).and_return(true)
+            expect(install.handle_tarball_path(pe_tarball_path, master)).to eq(pe_tarball_filename)
+          end
+        end
+
+        context "when the upload is not successful" do
+          it "raises an error" do
+            master = "localhost"
+            expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
+            expect(master).to receive(:equal?).with("localhost").and_return(true)
+            expect(File).to receive(:exist?).with(pe_tarball_path).and_return(true)
+            expect(install).to receive(:upload_pe_tarball)
+              .with(pe_tarball_path).and_return(false)
+
+            expect { install.handle_tarball_path(pe_tarball_path, master) }
+              .to raise_error(RuntimeError)
+          end
+        end
+      end
+
+      context "when the tarball does not exist" do
+        it "raises an error" do
+          master = "localhost"
+          expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
+          expect(master).to receive(:equal?).with("localhost").and_return(true)
+          expect(File).to receive(:exist?).with(pe_tarball_path).and_return(false)
+          expect(install).not_to receive(:upload_pe_tarball)
+          expect { install.handle_tarball_path(pe_tarball_path, master) }
+            .to raise_error(RuntimeError)
+        end
+      end
+    end
+
+    context "when the target master is not localhost" do
+      context "when the tarball is handled successfully" do
+        it "returns the filename" do
+          expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
+          expect(remote_target_master).to receive(:equal?).with("localhost").and_return(false)
+
+          expect(install).to receive(:handle_tarball_with_remote_target_master)
+            .with(pe_tarball_path, remote_target_master).and_return(true)
+
+          expect(install.handle_tarball_path(pe_tarball_path, remote_target_master)).to eq(pe_tarball_filename)
+        end
+      end
+
+      context "when the tarball is not handled successfully" do
+        it "raises an error" do
+          expect(File).to receive(:basename).with(pe_tarball_path).and_return(pe_tarball_filename)
+          expect(remote_target_master).to receive(:equal?).with("localhost").and_return(false)
+
+          expect(install).to receive(:handle_tarball_with_remote_target_master)
+            .with(pe_tarball_path, remote_target_master).and_return(false)
+
+          expect { install.handle_tarball_path(pe_tarball_path, remote_target_master) }
+            .to raise_error(RuntimeError)
+        end
+      end
+    end
+  end
+
+  describe "#handle_pe_tarball" do
+    context "when the extension is valid" do
+      context "when the tarball path is a valid URL" do
+        context "when the tarball URL is handled successfully" do
+          it "returns the tarball path on the master" do
+            expect(install).to receive(:valid_extension?).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:valid_tarball_url?).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:handle_tarball_url).with(pe_tarball_url, target_master)
+                                                           .and_return(pe_tarball_filename)
+
+            expect(install.handle_pe_tarball(pe_tarball_url, target_master)).to eq(master_tarball_path)
+          end
+        end
+
+        context "when the tarball URL is not handled successfully" do
+          it "raises an error" do
+            expect(install).to receive(:valid_extension?).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:valid_tarball_url?).with(pe_tarball_url).and_return(true)
+            expect(install).to receive(:handle_tarball_url).with(pe_tarball_url, target_master)
+                                                           .and_return(nil)
+
+            expect { install.handle_pe_tarball(pe_tarball_url, target_master) }
+              .to raise_error(RuntimeError)
+          end
+        end
+      end
+
+      context "when the tarball path is not a valid URL and a path is assumed" do
+        context "when the tarball path is handled successfully" do
+          it "returns the tarball path on the master" do
+            expect(install).to receive(:valid_extension?).with(pe_tarball_path).and_return(true)
+            expect(install).to receive(:valid_tarball_url?).with(pe_tarball_path).and_return(false)
+            expect(install).to receive(:handle_tarball_path).with(pe_tarball_path, target_master)
+                                                            .and_return(pe_tarball_filename)
+
+            expect(install.handle_pe_tarball(pe_tarball_path, target_master)).to eq(master_tarball_path)
+          end
+        end
+
+        context "when the tarball path is not handled successfully" do
+          it "raises an error" do
+            expect(install).to receive(:valid_extension?).with(pe_tarball_path).and_return(true)
+            expect(install).to receive(:valid_tarball_url?).with(pe_tarball_path).and_return(false)
+            expect(install).to receive(:handle_tarball_path).with(pe_tarball_path, target_master)
+                                                            .and_return(nil)
+
+            expect { install.handle_pe_tarball(pe_tarball_path, target_master) }
+              .to raise_error(RuntimeError)
+          end
+        end
+      end
+    end
+
+    context "when the extension is not valid" do
+      it "raises an error" do
+        path = "invalid"
+        expect(install).to receive(:valid_extension?).with(path).and_return(false)
+        expect { install.handle_pe_tarball(path, target_master) }
+          .to raise_error(RuntimeError)
       end
     end
   end


### PR DESCRIPTION
This update adds functionality to handle the specified PE tarball path whether specified as a URL or file path.

If a URL is specified with a remote target master the first download attempt will be directly to the target master. If unsuccessful the second attempt will be to the local node; if successful the file will then be uploaded to the target master.

If a file path is specified with a remote target master and the path includes the prefix `{TARGET_MASTER}:` (i.e. `the_master:/tmp/file.tar.gz`) it will be copied from the specified location to the temp working dir. If no prefix is specified the file is assumed to be on the local node and will be uploaded to the target master.

Hopefully this covers all possible combinations of localhost master / remote master and URL / (local file / remote file).

The check for running locally on the target master needs to be improved.
