### PR TITLE
(SLV-201) Updated acceptance pre-suite to use rbenv, added local install tests

### DIFF
--- a/acceptance/config/options.rb
+++ b/acceptance/config/options.rb
@@ -16,7 +16,7 @@
   :type                        => "pe",
   :pre_suite                   => [
     "acceptance/pre_suites/10_setup_ssh.rb",
-    "acceptance/pre_suites/20_setup_ruby.rb",
+    "acceptance/pre_suites/20_install_rbenv.rb",
     "acceptance/pre_suites/25_install_gems.rb",
     "acceptance/pre_suites/30_setup_ras.rb",
     "acceptance/pre_suites/40_download_pe_tarball.rb"
@@ -24,7 +24,10 @@
   :tests => [
     "acceptance/tests/10_install_test_remote_master_tarball_url.rb",
     "acceptance/tests/20_install_test_remote_master_tarball_path_controller.rb",
-    "acceptance/tests/30_install_test_remote_master_tarball_path_master.rb"
+    "acceptance/tests/30_install_test_remote_master_tarball_path_master.rb",
+    "acceptance/tests/40_install_test_local_master_tarball_url.rb",
+    "acceptance/tests/50_install_test_local_master_tarball_path.rb"
+
   ],
   "is_puppetserver"            => true,
   "use-service"                => true, # use service scripts to start/stop stuff

--- a/acceptance/pre_suites/20_install_rbenv.rb
+++ b/acceptance/pre_suites/20_install_rbenv.rb
@@ -1,0 +1,54 @@
+# rubocop:disable Metrics/BlockLength
+test_name "install rbenv" do
+  step "install dependencies" do
+    command = "yum install -y git-core zlib zlib-devel gcc-c++ patch" \
+              " readline readline-devel libyaml-devel libffi-devel openssl-devel" \
+              " make bzip2 autoconf automake libtool bison curl sqlite-devel"
+
+    puts command
+    on controller, command
+  end
+
+  step "install rbenv" do
+    url = "https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer"
+    command = "curl -fsSL #{url} | bash"
+
+    puts command
+
+    begin
+      on controller, command
+    rescue
+      puts "Error encountered... this is expected from rbenv-doctor"
+    end
+  end
+
+  step "export path" do
+    line = "export PATH=$PATH:$HOME/.rbenv/bin"
+    command = "echo #{line} >> ~/.bashrc"
+
+    puts command
+    on controller, command
+  end
+
+  step "rbenv init" do
+    line = 'eval "$(rbenv init -)"'
+    command = "echo #{line} >> ~/.bashrc"
+
+    puts command
+    on controller, command
+  end
+
+  step "install ruby" do
+    command = "rbenv install -v 2.4.2"
+
+    puts command
+    on controller, command
+  end
+
+  step "set global" do
+    command = "rbenv global 2.4.2"
+
+    puts command
+    on controller, command
+  end
+end

--- a/acceptance/tests/40_install_test_local_master_tarball_url.rb
+++ b/acceptance/tests/40_install_test_local_master_tarball_url.rb
@@ -1,0 +1,20 @@
+test_name "perform install on local master with tarball url" do
+  step "perform install" do
+    pe_url = get_pe_tarball_url(controller)
+    primary_master = "--primary-master=localhost"
+    pe_tarball = "--pe-tarball=#{pe_url}"
+    pe_conf = "--pe-conf=#{RAS_PE_CONF}"
+    command = "ref_arch_setup install #{primary_master} #{pe_tarball} #{pe_conf}"
+
+    puts command
+    on controller, command
+  end
+
+  step "run puppet agent" do
+    on controller, "puppet agent -t"
+  end
+
+  teardown do
+    ras_teardown(controller)
+  end
+end

--- a/acceptance/tests/50_install_test_local_master_tarball_path.rb
+++ b/acceptance/tests/50_install_test_local_master_tarball_path.rb
@@ -1,0 +1,20 @@
+test_name "perform install on local master with tarball path" do
+  step "perform install" do
+    filename = get_pe_tarball_filename(controller)
+    primary_master = "--primary-master=localhost"
+    pe_tarball = "--pe-tarball=#{RAS_PATH}/#{filename}"
+    pe_conf = "--pe-conf=#{RAS_PE_CONF}"
+    command = "ref_arch_setup install #{primary_master} #{pe_tarball} #{pe_conf}"
+
+    puts command
+    on controller, command
+  end
+
+  step "run puppet agent" do
+    on controller, "puppet agent -t"
+  end
+
+  teardown do
+    ras_teardown(controller)
+  end
+end


### PR DESCRIPTION
The acceptance tests currently use rvm to install ruby 2.4.2 during the pre-suite. This works for the remote install scenarios but fails for local install scenarios due to an incompatibility between rvm and the PE installer. 

This update replaces rvm with rbenv and includes the local install scenarios which now complete successfully.