### PR TITLE
(SLV-130) Use gem_of as a submodule, use Beaker 4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gem_of"]
+	path = gem_of
+	url = https://github.com/puppetlabs/gem_of.git

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
 AllCops:
   TargetRubyVersion: 2.3
+  Exclude:
+    - "Boltdir/**/*"
+    - "fixtures/**/*"
+    - "gem_of/**/*"
+    - "vendor/**/*"
 
 # Single quotes being faster is hardly measurable and only affects parse time.
 # # Enforcing double quotes reduces the times where you need to change them

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 * Make sure you have a [GitHub](https://github.com) account.
 * Clone the [ref_arch_setup](https://github.com/puppetlabs/ref_arch_setup) repository on GitHub.
-* RefArchSetup uses [gem_of](https://github.com/puppetlabs/gem_of) for the gemfile and rake tasks.
+* RefArchSetup uses [gem_of](https://github.com/puppetlabs/gem_of) for some development gem dependencies and rake tasks.
    Initialize and update the `gem_of` submodule:
   ```
   git submodule init
@@ -17,11 +17,11 @@
 
 ## Filing Tickets With Jira
 
-* Create a [Jira](http://tickets.puppetlabs.com) account.
+* Create a [Jira](http://tickets.puppetlabs.com) account if you don't already have one.
 * Submit a ticket for your issue, assuming one does not already exist:
+  * File a ticket in the [SLV project](https://tickets.puppetlabs.com/projects/SLV/).
   * Clearly describe the issue including steps to reproduce when it is a bug.
-  * File a ticket in the [SLV project](https://tickets.puppetlabs.com/projects/SLV/)
-
+  
 ## Making Changes
 
 ### GitHub

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,25 @@
 
 ## Getting Started
 
-* Create a [Jira](http://tickets.puppetlabs.com) account.
 * Make sure you have a [GitHub](https://github.com) account.
-* Submit a ticket for your issue, assuming one does not already exist.
+* Clone the [ref_arch_setup](https://github.com/puppetlabs/ref_arch_setup) repository on GitHub.
+* RefArchSetup uses [gem_of](https://github.com/puppetlabs/gem_of) for the gemfile and rake tasks.
+   Initialize and update the `gem_of` submodule:
+  ```
+  git submodule init
+  git submodule update
+  ```
+* Install the required gems:
+  ```
+  bundle install 
+  ```
+
+## Filing Tickets With Jira
+
+* Create a [Jira](http://tickets.puppetlabs.com) account.
+* Submit a ticket for your issue, assuming one does not already exist:
   * Clearly describe the issue including steps to reproduce when it is a bug.
   * File a ticket in the [SLV project](https://tickets.puppetlabs.com/projects/SLV/)
-* Clone the [ref_arch_setup](https://github.com/puppetlabs/ref_arch_setup) repository on GitHub.
 
 ## Making Changes
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
-require "gem_of"
+require "./gem_of/lib/gem_of"
+
+# required with beaker 4
+gem "beaker-vmpooler"
 
 eval(GemOf::Gems.new, binding) # rubocop:disable Security/Eval
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,5 @@
 require "./gem_of/lib/gem_of"
 
-# required with beaker 4
-gem "beaker-vmpooler"
-
 eval(GemOf::Gems.new, binding) # rubocop:disable Security/Eval
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,8 @@
 require "fileutils"
 require "rototiller"
-require "yard"
-require "rubocop/rake_task"
-require "flog_task"
-require "flay_task"
-require "roodi_task"
-require "rubycritic/rake_task"
-
+require "./gem_of/lib/gem_of/rake_tasks"
 require "./acceptance/helpers/beaker_helper"
+
 include BeakerHelper
 
 YARD_DIR = "doc".freeze
@@ -16,6 +11,11 @@ DOCS_DIR = "docs".freeze
 task :default do
   sh %(rake -T)
 end
+
+GemOf::GemTasks.new
+GemOf::YardStickTasks.new
+GemOf::DocsTasks.new
+GemOf::LintTasks.new
 
 # rubocop:disable Metrics/BlockLength
 namespace :test do
@@ -82,98 +82,6 @@ end
 
 task :test do
   Rake::Task["test:spec"].invoke
-end
-
-# bunch of gem build, clean, install, release tasks
-namespace :gem do
-  require "bundler/gem_tasks"
-end
-
-# various yarddoc docs tasks
-#   arch, clean, measure, undoc, verify, yard
-# rubocop:disable Metrics/BlockLength
-namespace :docs do
-  # docs:yard task
-  YARD::Rake::YardocTask.new
-
-  desc "Clean/remove the generated YARD Documentation cache"
-  task :clean do
-    original_dir = Dir.pwd
-    Dir.chdir(File.expand_path(__dir__))
-    sh "rm -rf #{YARD_DIR}"
-    Dir.chdir(original_dir)
-  end
-
-  desc "Tell me about YARD undocumented objects"
-  YARD::Rake::YardocTask.new(:undoc) do |t|
-    t.stats_options = ["--list-undoc"]
-  end
-
-  desc "Measure YARD coverage"
-  require "yardstick/rake/measurement"
-  options = YAML.load_file(".yardstick.yml")
-  Yardstick::Rake::Measurement.new(:measure, options) do |measurement|
-    measurement.output = "yardstick/report.txt"
-  end
-
-  desc "Verify YARD coverage"
-  require "yardstick/rake/verify"
-  config = { "require_exact_threshold" => false }
-  Yardstick::Rake::Verify.new(:verify, config) do |verify|
-    verify.threshold = 80
-  end
-
-  desc "Generate static project architecture graph. (Calls docs:yard)"
-  # this calls `yard graph` so we can't use the yardoc tasks like above
-  #   We could create a YARD:CLI:Graph object.
-  #   But we still have to send the output to the graphviz processor, etc.
-  task arch: [:yard] do
-    original_dir = Dir.pwd
-    Dir.chdir(File.expand_path(__dir__))
-    graph_processor = "dot"
-    if exe_exists?(graph_processor)
-      FileUtils.mkdir_p(DOCS_DIR)
-      if system("yard graph --full | #{graph_processor} -Tpng " \
-          "-o #{DOCS_DIR}/arch_graph.png")
-        puts "we made you a class diagram: #{DOCS_DIR}/arch_graph.png"
-      end
-    else
-      puts "ERROR: you don't have dot/graphviz; punting"
-    end
-    Dir.chdir(original_dir)
-  end
-end
-# rubocop:enable Metrics/BlockLength
-
-namespace :lint do
-  desc "check number of lines of code changed. To protect against long PRs"
-  task "diff_length" do
-    max_length = 150
-    target_branch = ENV["DISTELLI_RELBRANCH"] || "master"
-    diff_cmd = "git diff --numstat #{target_branch}"
-    sum_cmd  = "awk '{s+=$1} END {print s}'"
-    cmd      = "[ `#{diff_cmd} | #{sum_cmd}` -lt #{max_length} ]"
-    puts "checking if diff length is less than #{max_length} LoC"
-    exit system(cmd)
-  end
-
-  # this will produce the 'lint:rubocop','lint:rubocop:auto_correct' tasks
-  RuboCop::RakeTask.new do |task|
-    task.options = ["--debug"]
-  end
-
-  # this will produce the 'lint:flog' task
-  allowed_complexity = 585 # <cough!>
-  FlogTask.new :flog, allowed_complexity, %w[lib]
-  # this will produce the 'lint:flay' task
-  allowed_repitition = 0
-  FlayTask.new :flay, allowed_repitition, %w[lib]
-  # this will produce the 'lint:roodi' task
-  RoodiTask.new
-  # this will produce the 'lint:rubycritic' task
-  RubyCritic::RakeTask.new do |task|
-    task.paths   = FileList["lib/**/*.rb"]
-  end
 end
 
 # Cross-platform exe_exists?

--- a/distelli-manifest.yml
+++ b/distelli-manifest.yml
@@ -1,5 +1,8 @@
 slv/ref_arch_setup:
   PreBuild:
+    # Initialize and update gem_of submodule
+    - git submodule init
+    - git submodule update
     # Check to see if rvm is already installed
     - if [ -a ~/.rvm/scripts/rvm ]; then
     -   echo "rvm exists"

--- a/distelli-manifest.yml
+++ b/distelli-manifest.yml
@@ -15,12 +15,6 @@ slv/ref_arch_setup:
     - rvm install ruby-2.4.0
     - rvm use 2.4.0
     - gem install bundler
-    - git clone https://github.com/puppetlabs/gem_of.git
-    - cd gem_of
-    - gem build gem_of.gemspec
-    - gem install --local gem_of-*
-    - cd ..
-    - rm -rf gem_of
 
   Build:
     - source ~/.rvm/scripts/rvm

--- a/ref_arch_setup.gemspec
+++ b/ref_arch_setup.gemspec
@@ -23,5 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "bolt", "~> 0.17"
 
   # Development dependencies
-  spec.add_development_dependency "beaker", "~> 3.0"
+  # spec.add_development_dependency "beaker", "~> 3.0"
+  spec.add_runtime_dependency "beaker", "~>4.0"
+  spec.add_runtime_dependency "beaker-vmpooler"
 end

--- a/ref_arch_setup.gemspec
+++ b/ref_arch_setup.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "bolt", "~> 0.17"
 
   # Development dependencies
-  # spec.add_development_dependency "beaker", "~> 3.0"
   spec.add_runtime_dependency "beaker", "~>4.0"
   spec.add_runtime_dependency "beaker-vmpooler"
 end


### PR DESCRIPTION
With this update gem_of is now used as a submodule. When running the acceptance tests I noticed beaker-vmpooler was not loaded because gem_of was now using Beaker 4. Since we already ~~have a ticket to investigate~~ talked about updating to Beaker 4 I decided to pursue this option rather than trying to force it to use Beaker 3. The acceptance tests pass with this update.