### PR TITLE
(SLV-131) Update Bolt to 0.22.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Boltdir/
 doc/
 pkg/
 Gemfile.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,17 @@
 ## Getting Started
 
 * Make sure you have a [GitHub](https://github.com) account.
-* Clone the [ref_arch_setup](https://github.com/puppetlabs/ref_arch_setup) repository on GitHub.
-* RefArchSetup uses [gem_of](https://github.com/puppetlabs/gem_of) for some development gem dependencies and rake tasks.
-   Initialize and update the `gem_of` submodule:
-  ```
-  git submodule init
-  git submodule update
-  ```
+* Clone the [ref_arch_setup](https://github.com/puppetlabs/ref_arch_setup) repository on GitHub. 
+    * RefArchSetup uses [gem_of](https://github.com/puppetlabs/gem_of) for some development gem dependencies and rake tasks.
+    * Clone the repository and include the `gem_of` submodule:
+      ```
+      git clone --recurse-submodules https://github.com/puppetlabs/ref_arch_setup.git
+      ```
+    * If you've already cloned the repository you'll need to initialize and update the `gem_of` submodule:
+      ```
+      git submodule init
+      git submodule update
+      ```
 * Install the required gems:
   ```
   bundle install 

--- a/acceptance/pre_suites/25_install_gems.rb
+++ b/acceptance/pre_suites/25_install_gems.rb
@@ -1,9 +1,4 @@
 test_name "install bolt and gem-path on controller" do
-  # ras requires bolt
-  step "install bolt" do
-    on controller, "gem install bolt"
-  end
-
   # gem path is used to find ras
   step "install gem-path" do
     on controller, "gem install gem-path"

--- a/ref_arch_setup.gemspec
+++ b/ref_arch_setup.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Run time dependencies
-  spec.add_runtime_dependency "bolt", "~> 0.17"
+  spec.add_runtime_dependency "bolt", "~> 0.22.0"
 
   # Development dependencies
-  spec.add_runtime_dependency "beaker", "~>4.0"
-  spec.add_runtime_dependency "beaker-vmpooler"
+  spec.add_development_dependency "beaker", "~>4.0"
+  spec.add_development_dependency "beaker-vmpooler"
 end


### PR DESCRIPTION
This update replaces Bolt 0.17 with 0.22. This requires an update to the version of simplecov specified by gem_of; 0.14.0 is currently specified while 0.16.0 is required. The following PR has been submitted for this update: [(SLV-221) Update simplecov to 0.16.0](https://github.com/puppetlabs/gem_of/pull/6).

Once the above PR has been merged I will update the gem_of submodule and include that commit in this PR. In the meantime this PR can be tested by checking out the SLV-221 branch in the submodule.

The CONTRIBUTING.md file has also been updated to include the `--recurse-submodules` option when cloning the repository.