### PR TITLE
(SLV-131) Install modules from the Puppet Forge via Puppetfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Boltdir/
+Boltdir/modules/
 doc/
 pkg/
 Gemfile.lock

--- a/Boltdir/Puppetfile
+++ b/Boltdir/Puppetfile
@@ -1,0 +1,2 @@
+# Modules from the Puppet Forge
+mod "puppetlabs-facts", "0.2.0"

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require "fileutils"
 require "rototiller"
 require "./gem_of/lib/gem_of/rake_tasks"
 require "./acceptance/helpers/beaker_helper"
+require "./lib/ref_arch_setup/bolt_helper.rb"
 
 include BeakerHelper
 
@@ -17,6 +18,18 @@ GemOf::YardStickTasks.new
 GemOf::DocsTasks.new
 GemOf::LintTasks.new
 
+namespace :bolt do
+  desc "Install modules from the forge via Puppetfile"
+  task :install_forge_modules do
+    RefArchSetup::BoltHelper.install_forge_modules
+  end
+
+  desc "Run the facts::retrieve plan locally"
+  task :facts do
+    RefArchSetup::BoltHelper.run_forge_plan_with_bolt("facts::retrieve", nil, "localhost")
+  end
+end
+
 # rubocop:disable Metrics/BlockLength
 namespace :test do
   desc "Create hosts.cfg file"
@@ -28,6 +41,7 @@ namespace :test do
   desc "Run acceptance test using Beaker subcommands"
   task :acceptance do
     beaker_initialize
+    Rake::Task["bolt:install_forge_modules"].execute
     Rake::Task["gem:build"].execute
     Rake::Task["test:acceptance_init"].execute
     Rake::Task["test:acceptance_provision"].execute

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -2,7 +2,9 @@
 module RefArchSetup
   # Bolt helper methods
   class BoltHelper
+    # location of modules downloaded from the Puppet Forge
     FORGE_MODULE_PATH = File.dirname(__FILE__) + "/../../Boltdir/modules"
+
     @bolt_options = {}
 
     # gets the bolt options as a string

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -102,7 +102,7 @@ module RefArchSetup
     # @param nodes [string] Host or space delimited hosts to run task on
     # @param modulepath [string] The modulepath to use when running bolt
     #
-    # @return [true,false] Based on exit status of the bolt task
+    # @return [string] The output from the bolt run
     def self.run_plan_with_bolt(plan, params, nodes, modulepath = RAS_MODULE_PATH)
       params_str = ""
       params_str = params_to_string(params) unless params.nil?
@@ -117,7 +117,7 @@ module RefArchSetup
       puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
       raise "ERROR: bolt plan failed!" unless success
 
-      return success
+      return output
     end
 
     # Run a task from the forge with bolt on given nodes
@@ -143,7 +143,7 @@ module RefArchSetup
     # @param nodes [string] Host or space delimited hosts to run task on
     # @param modulepath [string] The modulepath to use when running bolt
     #
-    # @return [true,false] Based on exit status of the bolt plan
+    # @return [string] The output from the bolt run
     def self.run_forge_plan_with_bolt(plan, params, nodes)
       run_plan_with_bolt(plan, params, nodes, FORGE_MODULE_PATH)
     end

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -97,7 +97,7 @@ module RefArchSetup
     #
     # @author Sam Woods
     #
-    # @param task [string] Task to run on nodes
+    # @param plan [string] Plan to run on nodes
     # @param params [hash] Plan parameters to send to bolt
     # @param nodes [string] Host or space delimited hosts to run plan on
     # @param modulepath [string] The modulepath to use when running bolt
@@ -130,6 +130,7 @@ module RefArchSetup
     #
     # @return [true,false] Based on exit status of the bolt task
     def self.run_forge_task_with_bolt(task, params, nodes)
+      install_forge_modules
       run_task_with_bolt(task, params, nodes, FORGE_MODULE_PATH)
     end
 
@@ -143,6 +144,7 @@ module RefArchSetup
     #
     # @return [string] The output from the bolt run
     def self.run_forge_plan_with_bolt(plan, params, nodes)
+      install_forge_modules
       run_plan_with_bolt(plan, params, nodes, FORGE_MODULE_PATH)
     end
 

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -76,7 +76,7 @@ module RefArchSetup
     # @param modulepath [string] The modulepath to use when running bolt
     #
     # @return [true,false] Based on exit status of the bolt task
-    def self.run_task_with_bolt(task, params, nodes, modulepath=RAS_MODULE_PATH)
+    def self.run_task_with_bolt(task, params, nodes, modulepath = RAS_MODULE_PATH)
       params_str = ""
       params_str = params_to_string(params) unless params.nil?
       command = "bolt task run #{task} #{params_str}"
@@ -103,7 +103,7 @@ module RefArchSetup
     # @param modulepath [string] The modulepath to use when running bolt
     #
     # @return [true,false] Based on exit status of the bolt task
-    def self.run_plan_with_bolt(plan, params, nodes, modulepath=RAS_MODULE_PATH)
+    def self.run_plan_with_bolt(plan, params, nodes, modulepath = RAS_MODULE_PATH)
       params_str = ""
       params_str = params_to_string(params) unless params.nil?
       command = "bolt plan run #{plan} #{params_str}"
@@ -203,9 +203,5 @@ module RefArchSetup
 
       return success
     end
-
   end
-
-
-
 end

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -2,6 +2,7 @@
 module RefArchSetup
   # Bolt helper methods
   class BoltHelper
+    FORGE_MODULE_PATH = File.dirname(__FILE__) + "/../../Boltdir/modules"
     @bolt_options = {}
 
     # gets the bolt options as a string
@@ -72,13 +73,14 @@ module RefArchSetup
     # @param task [string] Task to run on nodes
     # @param params [hash] task parameters to send to bolt
     # @param nodes [string] Host or space delimited hosts to run task on
+    # @param modulepath [string] The modulepath to use when running bolt
     #
     # @return [true,false] Based on exit status of the bolt task
-    def self.run_task_with_bolt(task, params, nodes)
+    def self.run_task_with_bolt(task, params, nodes, modulepath=RAS_MODULE_PATH)
       params_str = ""
       params_str = params_to_string(params) unless params.nil?
       command = "bolt task run #{task} #{params_str}"
-      command << " --modulepath #{RAS_MODULE_PATH} --nodes #{nodes}"
+      command << " --modulepath #{modulepath} --nodes #{nodes}"
       command << bolt_options_string
       puts "Running: #{command}"
       output = `#{command}`
@@ -89,6 +91,61 @@ module RefArchSetup
       raise "ERROR: bolt task failed!" unless success
 
       return success
+    end
+
+    # Run a plan with bolt on given nodes
+    #
+    # @author Sam Woods
+    #
+    # @param task [string] Task to run on nodes
+    # @param params [hash] task parameters to send to bolt
+    # @param nodes [string] Host or space delimited hosts to run task on
+    # @param modulepath [string] The modulepath to use when running bolt
+    #
+    # @return [true,false] Based on exit status of the bolt task
+    def self.run_plan_with_bolt(plan, params, nodes, modulepath=RAS_MODULE_PATH)
+      params_str = ""
+      params_str = params_to_string(params) unless params.nil?
+      command = "bolt plan run #{plan} #{params_str}"
+      command << " --modulepath #{modulepath} --nodes #{nodes}"
+      command << bolt_options_string
+      puts "Running: #{command}"
+      output = `#{command}`
+      puts "Output was: #{output}"
+
+      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
+      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
+      raise "ERROR: bolt plan failed!" unless success
+
+      return success
+    end
+
+    # Run a task from the forge with bolt on given nodes
+    #
+    # @author Bill Claytor
+    #
+    # @param task [string] Task to run on nodes
+    # @param params [hash] Task parameters to send to bolt
+    # @param nodes [string] Host or space delimited hosts to run task on
+    # @param modulepath [string] The modulepath to use when running bolt
+    #
+    # @return [true,false] Based on exit status of the bolt task
+    def self.run_forge_task_with_bolt(task, params, nodes)
+      run_task_with_bolt(task, params, nodes, FORGE_MODULE_PATH)
+    end
+
+    # Run a plan from the forge with bolt on given nodes
+    #
+    # @author Bill Claytor
+    #
+    # @param plan [string] Plan to run on nodes
+    # @param params [hash] Plan parameters to send to bolt
+    # @param nodes [string] Host or space delimited hosts to run task on
+    # @param modulepath [string] The modulepath to use when running bolt
+    #
+    # @return [true,false] Based on exit status of the bolt plan
+    def self.run_forge_plan_with_bolt(plan, params, nodes)
+      run_plan_with_bolt(plan, params, nodes, FORGE_MODULE_PATH)
     end
 
     # Convert params to string for bolt
@@ -128,5 +185,27 @@ module RefArchSetup
 
       return success
     end
+
+    # Install modules from the forge via Puppetfile
+    #
+    # @author Bill Claytor
+    #
+    # @return [true,false] Based on exit status of the bolt task
+    def self.install_forge_modules
+      command = "bolt puppetfile install --modulepath #{FORGE_MODULE_PATH}"
+      puts "Running: #{command}"
+      output = `#{command}`
+      puts "Output was: #{output}"
+
+      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
+      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
+      raise "ERROR: bolt command failed!" unless success
+
+      return success
+    end
+
   end
+
+
+
 end

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -98,8 +98,8 @@ module RefArchSetup
     # @author Sam Woods
     #
     # @param task [string] Task to run on nodes
-    # @param params [hash] task parameters to send to bolt
-    # @param nodes [string] Host or space delimited hosts to run task on
+    # @param params [hash] Plan parameters to send to bolt
+    # @param nodes [string] Host or space delimited hosts to run plan on
     # @param modulepath [string] The modulepath to use when running bolt
     #
     # @return [string] The output from the bolt run
@@ -127,7 +127,6 @@ module RefArchSetup
     # @param task [string] Task to run on nodes
     # @param params [hash] Task parameters to send to bolt
     # @param nodes [string] Host or space delimited hosts to run task on
-    # @param modulepath [string] The modulepath to use when running bolt
     #
     # @return [true,false] Based on exit status of the bolt task
     def self.run_forge_task_with_bolt(task, params, nodes)
@@ -140,8 +139,7 @@ module RefArchSetup
     #
     # @param plan [string] Plan to run on nodes
     # @param params [hash] Plan parameters to send to bolt
-    # @param nodes [string] Host or space delimited hosts to run task on
-    # @param modulepath [string] The modulepath to use when running bolt
+    # @param nodes [string] Host or space delimited hosts to run plan on
     #
     # @return [string] The output from the bolt run
     def self.run_forge_plan_with_bolt(plan, params, nodes)

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -301,7 +301,6 @@ describe RefArchSetup::BoltHelper do
         expect(RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes, modulepath))
           .to eq(expected_output)
       end
-
     end
 
     context "when bolt works and returns output" do
@@ -341,9 +340,8 @@ describe RefArchSetup::BoltHelper do
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         allow(RefArchSetup::BoltHelper).to receive(:puts)
         expect(RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes))
-            .to eq(expected_output)
+          .to eq(expected_output)
       end
-
     end
 
     context "when bolt fails" do

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -226,30 +226,6 @@ describe RefArchSetup::BoltHelper do
       end
     end
 
-    context "when ssh user and password options are sent" do
-      before do
-        RefArchSetup::BoltHelper.bolt_options = bolt_user_opts
-        @expected_command_with_ssh = "#{@expected_command} #{bolt_user_string}"
-      end
-
-      it "passes the arguments to bolt" do
-        expected_output = "All Good"
-        expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
-          .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command_with_ssh).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)
-      end
-    end
-
     context "when ssh private key is sent" do
       before do
         RefArchSetup::BoltHelper.bolt_options = bolt_pkey_opts
@@ -493,28 +469,6 @@ describe RefArchSetup::BoltHelper do
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         expect { RefArchSetup::BoltHelper.upload_file(source, destination, nodes) }
           .to raise_error(error)
-      end
-    end
-
-    context "when ssh user and password options are sent" do
-      before do
-        RefArchSetup::BoltHelper.bolt_options = bolt_user_opts
-        @expected_command_with_ssh = "#{@expected_command} #{bolt_user_string}"
-      end
-
-      it "passes the arguments to bolt" do
-        expected_output = "All Good"
-        expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
-          .with(@expected_command_with_ssh).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes)).to eq(true)
       end
     end
 

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -376,6 +376,30 @@ describe RefArchSetup::BoltHelper do
           .to raise_error(error)
       end
     end
+
+    context "when ssh private key is sent" do
+      before do
+        RefArchSetup::BoltHelper.bolt_options = bolt_pkey_opts
+        @expected_command_with_ssh = "#{@expected_command} #{bolt_pkey_string}"
+      end
+
+      it "passes the argument to bolt" do
+        expected_output = "All Good"
+        expected_status = 0
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:`)
+          .with(@expected_command_with_ssh).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
+          .with("Running: #{@expected_command_with_ssh}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)
+      end
+    end
   end
 
   describe "run_forge_task_with_bolt" do

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -5,6 +5,7 @@ describe RefArchSetup::BoltHelper do
   let(:dir)               { "/tmp/ref_arch_setup" }
   let(:cmd)               { "echo foo" }
   let(:task)              { "ref_arch_setup::foo" }
+  let(:plan)              { "ref_arch_setup::foo_plan" }
   let(:params)            { { "VAR1" => "1", "VAR2" => "2" } }
   let(:params_str)        { "VAR1=1 VAR2=2" }
   let(:bolt_user_opts)    { { "user" => "my_user", "password" => "my_password" } }
@@ -240,6 +241,146 @@ describe RefArchSetup::BoltHelper do
     end
   end
 
+  describe "run_plan_with_bolt" do
+    before do
+      @expected_command = "bolt plan run #{plan} VAR1=1 VAR2=2 --modulepath "\
+      "#{RefArchSetup::RAS_MODULE_PATH} --nodes #{nodes}"
+    end
+
+    context "when bolt works and returns true" do
+      expected_output = "All Good"
+      expected_status = 0
+      it "returns true" do
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        allow(RefArchSetup::BoltHelper).to receive(:puts)
+        expect(RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)).to eq(true)
+      end
+      it "outputs informative messages" do
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)
+      end
+    end
+
+    context "when bolt fails and returns false" do
+      expected_output = "No Good"
+      expected_status = 1
+
+      it "raises an error" do
+        error = "ERROR: bolt plan failed!"
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
+        allow(RefArchSetup::BoltHelper).to receive(:puts)
+        expect { RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes) }
+            .to raise_error(error)
+      end
+      it "outputs informative messages and raises an error" do
+        error = "ERROR: bolt plan failed!"
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("Exit status was: #{expected_status}")
+        expect { RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes) }
+            .to raise_error(error)
+      end
+    end
+
+    context "when ssh user and password options are sent" do
+      before do
+        RefArchSetup::BoltHelper.bolt_options = bolt_user_opts
+        @expected_command_with_ssh = "#{@expected_command} #{bolt_user_string}"
+      end
+
+      it "passes the arguments to bolt" do
+        expected_output = "All Good"
+        expected_status = 0
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command_with_ssh).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
+                                                .with("Running: #{@expected_command_with_ssh}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)
+      end
+    end
+
+    context "when ssh private key is sent" do
+      before do
+        RefArchSetup::BoltHelper.bolt_options = bolt_pkey_opts
+        @expected_command_with_ssh = "#{@expected_command} #{bolt_pkey_string}"
+      end
+
+      it "passes the argument to bolt" do
+        expected_output = "All Good"
+        expected_status = 0
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command_with_ssh).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
+                                                .with("Running: #{@expected_command_with_ssh}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)
+      end
+    end
+  end
+
+  describe "run_forge_task_with_bolt" do
+    context "when bolt works and returns true" do
+      it "returns true" do
+        modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
+        expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
+          .with(task, params, nodes, modulepath).and_return(true)
+        expect(RefArchSetup::BoltHelper.run_forge_task_with_bolt(task, params, nodes)).to eq(true)
+      end
+    end
+
+  end
+
+  describe "run_forge_plan_with_bolt" do
+    context "when bolt works and returns true" do
+      it "returns true" do
+        modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
+        expect(RefArchSetup::BoltHelper).to receive(:run_plan_with_bolt)
+          .with(plan, params, nodes, modulepath).and_return(true)
+        expect(RefArchSetup::BoltHelper.run_forge_plan_with_bolt(plan, params, nodes)).to eq(true)
+      end
+    end
+
+  end
+
   describe "params_to_string" do
     context "params has 2 values" do
       it "stringifies them correctly" do
@@ -340,4 +481,53 @@ describe RefArchSetup::BoltHelper do
       end
     end
   end
+
+
+
+
+
+
+
+  describe "install_forge_modules" do
+    before do
+      modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
+      @expected_command = "bolt puppetfile install --modulepath "\
+      "#{modulepath}"
+    end
+
+    context "when bolt works and returns true" do
+      it "returns true and outputs informative messages" do
+        expected_output = "All Good"
+        expected_status = 0
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        expect(RefArchSetup::BoltHelper.install_forge_modules).to eq(true)
+      end
+    end
+
+    context "when bolt fails and returns false" do
+      it "outputs informative messages and raises an error" do
+        error = "ERROR: bolt command failed!"
+        expected_output = "No Good"
+        expected_status = 1
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        expect { RefArchSetup::BoltHelper.install_forge_modules }.to raise_error(error)
+      end
+    end
+
+  end
+
 end

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -247,10 +247,10 @@ describe RefArchSetup::BoltHelper do
       "#{RefArchSetup::RAS_MODULE_PATH} --nodes #{nodes}"
     end
 
-    context "when bolt works and returns true" do
+    context "when bolt works and returns output" do
       expected_output = "All Good"
       expected_status = 0
-      it "returns true" do
+      it "returns the output" do
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
           .with(params).and_return(params_str)
         expect(RefArchSetup::BoltHelper).to receive(:`)\
@@ -258,7 +258,8 @@ describe RefArchSetup::BoltHelper do
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         allow(RefArchSetup::BoltHelper).to receive(:puts)
-        expect(RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)).to eq(true)
+        expect(RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes))
+          .to eq(expected_output)
       end
       it "outputs informative messages" do
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
@@ -275,7 +276,7 @@ describe RefArchSetup::BoltHelper do
       end
     end
 
-    context "when bolt fails and returns false" do
+    context "when bolt fails" do
       expected_output = "No Good"
       expected_status = 1
 
@@ -358,8 +359,8 @@ describe RefArchSetup::BoltHelper do
   end
 
   describe "run_forge_task_with_bolt" do
-    context "when bolt works and returns true" do
-      it "returns true" do
+    context "when bolt works and returns output" do
+      it "returns the output" do
         modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
         expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
           .with(task, params, nodes, modulepath).and_return(true)
@@ -369,12 +370,14 @@ describe RefArchSetup::BoltHelper do
   end
 
   describe "run_forge_plan_with_bolt" do
-    context "when bolt works and returns true" do
-      it "returns true" do
+    context "when bolt works and returns output" do
+      it "returns the output" do
+        expected_output = "All Good"
         modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
         expect(RefArchSetup::BoltHelper).to receive(:run_plan_with_bolt)
-          .with(plan, params, nodes, modulepath).and_return(true)
-        expect(RefArchSetup::BoltHelper.run_forge_plan_with_bolt(plan, params, nodes)).to eq(true)
+          .with(plan, params, nodes, modulepath).and_return(expected_output)
+        expect(RefArchSetup::BoltHelper.run_forge_plan_with_bolt(plan, params, nodes))
+          .to eq(expected_output)
       end
     end
   end

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -27,7 +27,7 @@ describe RefArchSetup::BoltHelper do
 
     context "when run_cmd_with_bolt returns true" do
       it "returns true" do
-        expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)\
+        expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)
           .with(@expected_command, nodes).and_return(true)
         expect(RefArchSetup::BoltHelper.make_dir(dir, nodes)).to eq(true)
       end
@@ -36,7 +36,7 @@ describe RefArchSetup::BoltHelper do
     context "when run_cmd_with_bolt returns false" do
       it "raises an error" do
         error = "ERROR: Failed to make dir #{dir} on all nodes"
-        expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)\
+        expect(RefArchSetup::BoltHelper).to receive(:run_cmd_with_bolt)
           .with(@expected_command, nodes).and_return(false)
         expect { RefArchSetup::BoltHelper.make_dir(dir, nodes) }.to raise_error(error)
       end
@@ -52,12 +52,12 @@ describe RefArchSetup::BoltHelper do
       it "returns true and outputs informative messages" do
         expected_output = "All Good"
         expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(true)
@@ -69,12 +69,12 @@ describe RefArchSetup::BoltHelper do
         error = "ERROR: bolt command failed!"
         expected_output = "No Good"
         expected_status = 1
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         expect { RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes) }.to raise_error(error)
@@ -90,13 +90,13 @@ describe RefArchSetup::BoltHelper do
       it "executes bolt command with the arguments" do
         expected_output = "All Good"
         expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command_with_ssh).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(true)
@@ -111,13 +111,13 @@ describe RefArchSetup::BoltHelper do
       it "executes bolt command with the arguments" do
         expected_output = "All Good"
         expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command_with_ssh).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(true)
@@ -141,9 +141,9 @@ describe RefArchSetup::BoltHelper do
         @expected_command = "bolt task run #{task} VAR1=1 VAR2=2 --modulepath "\
           "#{modulepath} --nodes #{nodes}"
 
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
@@ -157,9 +157,9 @@ describe RefArchSetup::BoltHelper do
       expected_output = "All Good"
       expected_status = 0
       it "uses the default modulepath" do
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
@@ -168,9 +168,9 @@ describe RefArchSetup::BoltHelper do
       end
 
       it "returns true" do
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
@@ -179,14 +179,14 @@ describe RefArchSetup::BoltHelper do
       end
 
       it "outputs informative messages" do
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)
@@ -199,9 +199,9 @@ describe RefArchSetup::BoltHelper do
 
       it "raises an error" do
         error = "ERROR: bolt task failed!"
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
@@ -211,15 +211,15 @@ describe RefArchSetup::BoltHelper do
       end
       it "outputs informative messages and raises an error" do
         error = "ERROR: bolt task failed!"
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect { RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes) }
           .to raise_error(error)
@@ -235,15 +235,15 @@ describe RefArchSetup::BoltHelper do
       it "passes the arguments to bolt" do
         expected_output = "All Good"
         expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command_with_ssh).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)
@@ -259,15 +259,15 @@ describe RefArchSetup::BoltHelper do
       it "passes the argument to bolt" do
         expected_output = "All Good"
         expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command_with_ssh).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)
@@ -293,7 +293,7 @@ describe RefArchSetup::BoltHelper do
 
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
@@ -307,9 +307,9 @@ describe RefArchSetup::BoltHelper do
       expected_output = "All Good"
       expected_status = 0
       it "uses the default modulepath" do
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
@@ -318,23 +318,23 @@ describe RefArchSetup::BoltHelper do
       end
 
       it "outputs informative messages" do
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)
       end
 
       it "returns the output" do
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
@@ -350,9 +350,9 @@ describe RefArchSetup::BoltHelper do
 
       it "raises an error" do
         error = "ERROR: bolt plan failed!"
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
@@ -362,15 +362,15 @@ describe RefArchSetup::BoltHelper do
       end
       it "outputs informative messages and raises an error" do
         error = "ERROR: bolt plan failed!"
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect { RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes) }
           .to raise_error(error)
@@ -380,7 +380,13 @@ describe RefArchSetup::BoltHelper do
 
   describe "run_forge_task_with_bolt" do
     context "when bolt works and returns output" do
-      it "ensures the forge modules are installed and returns the output" do
+      it "ensures the forge modules are installed" do
+        expect(RefArchSetup::BoltHelper).to receive(:install_forge_modules)
+        expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
+        RefArchSetup::BoltHelper.run_forge_task_with_bolt(task, params, nodes)
+      end
+
+      it "returns the output" do
         modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
         expect(RefArchSetup::BoltHelper).to receive(:install_forge_modules)
         expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
@@ -392,7 +398,13 @@ describe RefArchSetup::BoltHelper do
 
   describe "run_forge_plan_with_bolt" do
     context "when bolt works and returns output" do
-      it "ensures the forge modules are installed and returns the output" do
+      it "ensures the forge modules are installed" do
+        expect(RefArchSetup::BoltHelper).to receive(:install_forge_modules)
+        expect(RefArchSetup::BoltHelper).to receive(:run_plan_with_bolt)
+        RefArchSetup::BoltHelper.run_forge_plan_with_bolt(plan, params, nodes)
+      end
+
+      it "returns the output" do
         expected_output = "All Good"
         modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
         expect(RefArchSetup::BoltHelper).to receive(:install_forge_modules)
@@ -507,41 +519,64 @@ describe RefArchSetup::BoltHelper do
 
   describe "install_forge_modules" do
     before do
-      modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
       @expected_command = "bolt puppetfile install --modulepath "\
-      "#{modulepath}"
+      "#{RefArchSetup::BoltHelper::FORGE_MODULE_PATH}"
     end
 
     context "when bolt works and returns true" do
-      it "returns true and outputs informative messages" do
+      it "outputs informative messages" do
         expected_output = "All Good"
         expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        RefArchSetup::BoltHelper.install_forge_modules
+      end
+
+      it "returns true" do
+        expected_output = "All Good"
+        expected_status = 0
+        expect(RefArchSetup::BoltHelper).to receive(:`)
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        allow(RefArchSetup::BoltHelper).to receive(:puts)
         expect(RefArchSetup::BoltHelper.install_forge_modules).to eq(true)
       end
     end
 
     context "when bolt fails and returns false" do
-      it "outputs informative messages and raises an error" do
-        error = "ERROR: bolt command failed!"
+      it "outputs informative messages (and raises an error)" do
         expected_output = "No Good"
         expected_status = 1
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
+        expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        expect { RefArchSetup::BoltHelper.install_forge_modules }.to raise_error(error)
+        expect { RefArchSetup::BoltHelper.install_forge_modules }.to raise_error(RuntimeError)
+      end
+
+      it "raises the expected error" do
+        error = "ERROR: bolt command failed!"
+        expected_output = "No Good"
+        expected_status = 1
+        expect(RefArchSetup::BoltHelper).to receive(:`)
+          .with(@expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
+        allow(RefArchSetup::BoltHelper).to receive(:puts)
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
+        expect { RefArchSetup::BoltHelper.install_forge_modules }
+          .to raise_error(RuntimeError, error)
       end
     end
   end

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -323,7 +323,7 @@ describe RefArchSetup::BoltHelper do
         expect(RefArchSetup::BoltHelper).to receive(:`)\
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
-        expect($CHILD_STATUS).to receive(:success?).and_return(true)
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
         expect(RefArchSetup::BoltHelper).to receive(:puts)\
           .with("Exit status was: #{expected_status}")

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -289,7 +289,7 @@ describe RefArchSetup::BoltHelper do
         expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
         allow(RefArchSetup::BoltHelper).to receive(:puts)
         expect { RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes) }
-            .to raise_error(error)
+          .to raise_error(error)
       end
       it "outputs informative messages and raises an error" do
         error = "ERROR: bolt plan failed!"
@@ -304,7 +304,7 @@ describe RefArchSetup::BoltHelper do
         expect(RefArchSetup::BoltHelper).to receive(:puts)\
           .with("Exit status was: #{expected_status}")
         expect { RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes) }
-            .to raise_error(error)
+          .to raise_error(error)
       end
     end
 
@@ -324,7 +324,7 @@ describe RefArchSetup::BoltHelper do
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts)
-                                                .with("Running: #{@expected_command_with_ssh}")
+          .with("Running: #{@expected_command_with_ssh}")
         expect(RefArchSetup::BoltHelper).to receive(:puts)\
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
@@ -348,7 +348,7 @@ describe RefArchSetup::BoltHelper do
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
         expect(RefArchSetup::BoltHelper).to receive(:puts)
-                                                .with("Running: #{@expected_command_with_ssh}")
+          .with("Running: #{@expected_command_with_ssh}")
         expect(RefArchSetup::BoltHelper).to receive(:puts)\
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
@@ -366,7 +366,6 @@ describe RefArchSetup::BoltHelper do
         expect(RefArchSetup::BoltHelper.run_forge_task_with_bolt(task, params, nodes)).to eq(true)
       end
     end
-
   end
 
   describe "run_forge_plan_with_bolt" do
@@ -378,7 +377,6 @@ describe RefArchSetup::BoltHelper do
         expect(RefArchSetup::BoltHelper.run_forge_plan_with_bolt(plan, params, nodes)).to eq(true)
       end
     end
-
   end
 
   describe "params_to_string" do
@@ -482,12 +480,6 @@ describe RefArchSetup::BoltHelper do
     end
   end
 
-
-
-
-
-
-
   describe "install_forge_modules" do
     before do
       modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
@@ -527,7 +519,5 @@ describe RefArchSetup::BoltHelper do
         expect { RefArchSetup::BoltHelper.install_forge_modules }.to raise_error(error)
       end
     end
-
   end
-
 end

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -131,10 +131,31 @@ describe RefArchSetup::BoltHelper do
       "#{RefArchSetup::RAS_MODULE_PATH} --nodes #{nodes}"
     end
 
+    context "when a modulepath is specified" do
+      expected_output = "All Good"
+      expected_status = 0
+      modulepath = "./my_modules"
+
+      it "uses the specified value" do
+        expected_command = "bolt task run #{task} VAR1=1 VAR2=2 --modulepath "\
+          "#{modulepath} --nodes #{nodes}"
+
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        allow(RefArchSetup::BoltHelper).to receive(:puts)
+        expect(RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes, modulepath))
+          .to eq(true)
+      end
+    end
+
     context "when bolt works and returns true" do
       expected_output = "All Good"
       expected_status = 0
-      it "returns true" do
+      it "uses the default modulepath and returns true" do
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
           .with(params).and_return(params_str)
         expect(RefArchSetup::BoltHelper).to receive(:`)\
@@ -144,7 +165,7 @@ describe RefArchSetup::BoltHelper do
         allow(RefArchSetup::BoltHelper).to receive(:puts)
         expect(RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)).to eq(true)
       end
-      it "outputs informative messages" do
+      it "uses the default modulepath and outputs informative messages" do
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
           .with(params).and_return(params_str)
         expect(RefArchSetup::BoltHelper).to receive(:`)\
@@ -247,10 +268,31 @@ describe RefArchSetup::BoltHelper do
       "#{RefArchSetup::RAS_MODULE_PATH} --nodes #{nodes}"
     end
 
+    context "when a modulepath is specified" do
+      expected_output = "All Good"
+      expected_status = 0
+      modulepath = "./my_modules"
+
+      it "uses the specified value" do
+        expected_command = "bolt plan run #{plan} VAR1=1 VAR2=2 --modulepath "\
+        "#{modulepath} --nodes #{nodes}"
+
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:`)\
+          .with(expected_command).and_return(expected_output)
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        allow(RefArchSetup::BoltHelper).to receive(:puts)
+        expect(RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes, modulepath))
+          .to eq(expected_output)
+      end
+    end
+
     context "when bolt works and returns output" do
       expected_output = "All Good"
       expected_status = 0
-      it "returns the output" do
+      it "uses the default modulepath and returns the output" do
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
           .with(params).and_return(params_str)
         expect(RefArchSetup::BoltHelper).to receive(:`)\
@@ -261,13 +303,13 @@ describe RefArchSetup::BoltHelper do
         expect(RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes))
           .to eq(expected_output)
       end
-      it "outputs informative messages" do
+      it "uses the default modulepath and outputs informative messages" do
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
           .with(params).and_return(params_str)
         expect(RefArchSetup::BoltHelper).to receive(:`)\
           .with(@expected_command).and_return(expected_output)
         `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+        expect($CHILD_STATUS).to receive(:success?).and_return(true)
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
         expect(RefArchSetup::BoltHelper).to receive(:puts)\
           .with("Exit status was: #{expected_status}")
@@ -306,54 +348,6 @@ describe RefArchSetup::BoltHelper do
           .with("Exit status was: #{expected_status}")
         expect { RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes) }
           .to raise_error(error)
-      end
-    end
-
-    context "when ssh user and password options are sent" do
-      before do
-        RefArchSetup::BoltHelper.bolt_options = bolt_user_opts
-        @expected_command_with_ssh = "#{@expected_command} #{bolt_user_string}"
-      end
-
-      it "passes the arguments to bolt" do
-        expected_output = "All Good"
-        expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
-          .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
-          .with(@expected_command_with_ssh).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)
-      end
-    end
-
-    context "when ssh private key is sent" do
-      before do
-        RefArchSetup::BoltHelper.bolt_options = bolt_pkey_opts
-        @expected_command_with_ssh = "#{@expected_command} #{bolt_pkey_string}"
-      end
-
-      it "passes the argument to bolt" do
-        expected_output = "All Good"
-        expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string) \
-          .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
-          .with(@expected_command_with_ssh).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 require "simplecov"
 require "rspec"
 
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/spec/"
+end
 
 require "ref_arch_setup"
 


### PR DESCRIPTION
This update includes the following:
 - Add a Boltdir with a Puppetfile specifying the facts module
 - Update bolt_helper to install modules using the Puppetfile and run tasks / plans using the modules installed in the Boltdir
 - Add rake tasks to install the modules and run the facts::retrieve plan locally