### PR TITLE
(SLV-131) Create a method that will determine the URL for a production release of PE based on a version

### DIFF
--- a/lib/ref_arch_setup.rb
+++ b/lib/ref_arch_setup.rb
@@ -1,6 +1,6 @@
 # General namespace for RAS
 module RefArchSetup
-  %w[cli bolt_helper version install].each do |lib|
+  %w[cli bolt_helper download_helper version install].each do |lib|
     require "ref_arch_setup/#{lib}"
   end
   # location of modules shipped with RAS (Ref Arch Setup)

--- a/lib/ref_arch_setup/download_helper.rb
+++ b/lib/ref_arch_setup/download_helper.rb
@@ -208,7 +208,7 @@ module RefArchSetup
       else
         is_valid_response = true
       end
-      is_valid_response
+      return is_valid_response
     end
 
     # Handles the host and platform and determines the appropriate PE platform

--- a/lib/ref_arch_setup/download_helper.rb
+++ b/lib/ref_arch_setup/download_helper.rb
@@ -1,0 +1,337 @@
+# rubocop:disable Metrics/ClassLength
+require "oga"
+require "net/http"
+
+# General namespace for RAS
+module RefArchSetup
+  # Download helper methods
+  class DownloadHelper
+    # the 'Puppet Enterprise Version History' url
+    PE_VERSIONS_URL = "https://puppet.com/misc/version-history".freeze
+
+    # the base of the URL where prod PE tarballs are hosted
+    BASE_PROD_URL = "https://s3.amazonaws.com/pe-builds/released".freeze
+
+    # the minimum prod version supported by RAS
+    MIN_PROD_VERSION = "2018.1.0".freeze
+
+    # the supported platforms for PE installation using RAS
+    PE_PLATFORMS = ["el-6-x86_64", "el-7-x86_64", "sles-12-x86_64", "ubuntu-16.04-amd64"].freeze
+
+    def initialize
+      @pe_versions_url = ENV["PE_VERSIONS_URL"] ? ENV["PE_VERSIONS_URL"] : PE_VERSIONS_URL
+      @base_prod_url = ENV["BASE_PROD_URL"] ? ENV["BASE_PROD_URL"] : BASE_PROD_URL
+      @min_prod_version = ENV["MIN_PROD_VERSION"] ? ENV["MIN_PROD_VERSION"] : MIN_PROD_VERSION
+      @pe_platforms = PE_PLATFORMS
+    end
+
+    # Builds the prod tarball URL for the specified or default version of PE
+    #
+    # @author Bill Claytor
+    #
+    # @param [string] version The desired version of PE (default = "latest")
+    # @param [string] host The target host for this PE tarball (default = "localhost")
+    # @param [string] platform The target platform for this PE tarball
+    #
+    # *** Specifying the host will determine and validate the platform for the host
+    # *** Specifying the platform will ignore the host value and only perform the validation
+    #
+    # @return [string] the prod tarball URL
+    #
+    # @example:
+    # url = build_prod_tarball_url()
+    # url = build_prod_tarball_url("2018.1.4", "master.mydomain.net", "")
+    # url = build_prod_tarball_url("2018.1.4", "value_is_ignored", "sles-12-x86_64")
+    #
+    def self.build_prod_tarball_url(version = "latest", host = "localhost", platform = "default")
+      pe_version = handle_prod_version(version)
+      pe_platform = handle_platform(host, platform)
+      url = "#{@base_prod_url}/#{pe_version}/puppet-enterprise-#{pe_version}-#{pe_platform}.tar.gz"
+      puts "URL: #{url}"
+      return url
+    end
+
+    # Handles the specified version of PE
+    #
+    # @author Bill Claytor
+    #
+    # @param [string] version The desired version of PE
+    #
+    # @return [string] The corresponding PE version
+    #
+    # @example:
+    #   version = handle_prod_version("latest")
+    #   version = handle_prod_version("2018.1.4")
+    #
+    def self.handle_prod_version(version)
+      if version == "latest"
+        pe_version = latest_prod_version
+        puts "The latest version is: #{pe_version}"
+      else
+        success = ensure_valid_prod_version(version) && ensure_supported_prod_version(version)
+        raise "Invalid version: #{version}" unless success
+
+        pe_version = version
+        puts "Using specified version: #{pe_version}"
+      end
+
+      return pe_version
+    end
+
+    # Retrieves the latest production version of PE from the 'Puppet Enterprise Version History'
+    #
+    # @author Bill Claytor
+    #
+    # @return [string] The latest production version of PE
+    #
+    # @example:
+    #   latest_version = latest_prod_version
+    #
+    def self.latest_prod_version
+      result = parse_prod_versions_url("//table/tbody/tr[1]/td[1]")
+      latest_version = result.text
+      return latest_version
+    end
+
+    # Determines whether the specified version is an actual production version of PE
+    #
+    # @author Bill Claytor
+    #
+    # @param [string] version The specified version of PE
+    #
+    # @return [true, false] Whether the specified version was found
+    #
+    # @example:
+    #   result = ensure_valid_prod_version("2018.1.4")
+    #
+    def self.ensure_valid_prod_version(version)
+      puts "Verifying specified PE version: #{version}"
+
+      result = parse_prod_versions_url("//table/tbody/tr/td[contains(., '#{version}')]")
+      found = result.text == version ? true : false
+
+      puts "Specified version #{version} was found" if found
+      raise "Specified version not found: #{version}" unless found
+
+      return found
+    end
+
+    # Determines whether the specified version is supported by RAS
+    #
+    # @author Bill Claytor
+    #
+    # @param [string] version The specified version of PE
+    #
+    # @return [true, false] Whether the specified version is supported
+    #
+    # @example:
+    #   result = ensure_supported_prod_version("2018.1.4")
+    #
+    def self.ensure_supported_prod_version(version)
+      major_version = version.split(".")[0]
+      supported_version = MIN_PROD_VERSION.split(".")[0]
+
+      supported = major_version >= supported_version ? true : false
+      puts "Specified version #{version} is supported by RAS" if supported
+      puts "The minimum supported version is #{MIN_PROD_VERSION}" unless supported
+
+      raise "Specified version #{version} is not supported by RAS" unless supported
+
+      return supported
+    end
+
+    # Fetches the list of production PE versions from the 'Puppet Enterprise Version History'
+    #
+    # @author Bill Claytor
+    #
+    # @return [string] The versions list
+    #
+    # @example:
+    #   versions = fetch_prod_versions
+    #
+    def self.fetch_prod_versions
+      versions = parse_prod_versions_url
+      return versions
+    end
+
+    # Parses the 'Puppet Enterprise Version History'
+    # using the specified xpath and returns the result
+    #
+    # @author Bill Claytor
+    #
+    # @param [string] xpath The xpath to use when parsing the version history
+    #
+    # @return [string] The result
+    #
+    # @example:
+    #   versions = parse_prod_versions_url
+    #   latest_version = parse_prod_versions_url("//table/tbody/tr[1]/td[1]")
+    #   result = parse_prod_versions_url("//table/tbody/tr/td[contains(., '#{version}')]")
+    #
+    def self.parse_prod_versions_url(xpath = "//table/tbody/tr/td[1]")
+      puts "Checking Puppet Enterprise Version History: #{@pe_versions_url}"
+
+      uri = URI.parse(@pe_versions_url)
+      response = Net::HTTP.get_response(uri)
+      raise "Invalid response" unless valid_response?(response)
+
+      document = Oga.parse_html(response.body)
+      result = document.xpath(xpath)
+      return result
+    end
+
+    # Determines whether the response is valid
+    #
+    # @author Bill Claytor
+    #
+    # @param [Net::HTTPResponse] res The HTTP response to evaluate
+    # @param [Array] valid_response_codes The list of valid response codes
+    # @param [Array] invalid_response_bodies The list of invalid response bodies
+    #
+    # @return [true,false] Based on whether the response is valid
+    #
+    # @example
+    #   valid = valid_response?(res)
+    #   valid = valid_response?(res, ["200", "123"], ["", nil], "xyz")
+    #
+    def self.valid_response?(res, valid_response_codes = ["200"],
+                             invalid_response_bodies = ["", nil])
+      # TODO: other criteria?
+      is_valid_response = false
+
+      if res.nil? || !valid_response_codes.include?(res.code) ||
+         invalid_response_bodies.include?(res.body)
+        puts "Invalid response:"
+        puts "code: #{res.code}" unless res.nil?
+        puts "body: #{res.body}" unless res.nil?
+        puts
+      else
+        is_valid_response = true
+      end
+      is_valid_response
+    end
+
+    # Handles the host and platform and determines the appropriate PE platform
+    #
+    # @author Bill Claytor
+    #
+    # @param [string] host The target host for this PE tarball (default = "localhost")
+    # @param [string] platform The target platform for this PE tarball
+    #
+    # *** Specifying the host will determine and validate the platform for the host
+    # *** Specifying the platform will ignore the host value and only perform the validation
+    #
+    # @return [string] The PE platform
+    #
+    # @example:
+    #   handle_platform("my_host", "default")
+    #   handle_platform("value_is_ignored", "sles-12-x86_64")
+    #
+    def self.handle_platform(host, platform)
+      if platform == "default"
+        puts "Default platform specified; determining platform for host"
+        pe_platform = handle_platform_for_host(host)
+      else
+        puts "Specified platform: #{platform}"
+        pe_platform = platform
+      end
+      raise "Invalid PE platform: #{pe_platform}" unless valid_platform?(pe_platform)
+      return pe_platform
+    end
+
+    # Handles the platform for the specified host using the host's facts
+    #
+    # @author Bill Claytor
+    #
+    # @param [string] host The target host
+    #
+    # @return [string] The corresponding platform for the specified host
+    #
+    # @example:
+    #   platform = handle_platform_for_host("localhost")
+    #
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
+    def self.handle_platform_for_host(host)
+      facts = retrieve_facts(host)
+      os = facts[0]["result"]["os"]
+      os_name = os["name"]
+      os_family = os["family"]
+      platform_type = nil
+
+      case os_family
+      when "RedHat"
+        platform_type = "el"
+        platform_arch = "x86_64"
+        release = os["release"]["major"]
+      when "SLES"
+        platform_type = "sles"
+        platform_arch = "x86_64"
+        release = os["release"]["major"]
+      when "Debian"
+        if os_name == "Ubuntu"
+          platform_type = "ubuntu"
+          platform_arch = "amd64"
+          release = os["release"]["full"]
+        end
+      end
+
+      raise "Unable to determine platform for host: #{host}" unless platform_type
+      platform = "#{platform_type}-#{release}-#{platform_arch}"
+      puts "Host platform: #{platform}"
+
+      return platform
+    end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
+
+    # Retrieves the facts for the specified host(s) using the facts::retrieve plan
+    #
+    # @author Bill Claytor
+    #
+    # @param [string] hosts The host(s) from which to retrieve facts
+    #
+    # @return [string] The retrieved facts
+    #
+    # @example:
+    #   facts = retrieve_facts("localhost")
+    #
+    def self.retrieve_facts(hosts)
+      plan = "facts::retrieve"
+      puts "Retrieving facts for hosts: #{hosts}"
+
+      output = BoltHelper.run_forge_plan_with_bolt(plan, nil, hosts)
+
+      begin
+        facts = JSON.parse(output)
+      rescue
+        puts "Unable to parse bolt output"
+        raise
+      end
+
+      return facts
+    end
+
+    # Determines whether the specified platform is a valid PE platform
+    #
+    # @author Bill Claytor
+    #
+    # @param [string] platform The platform
+    #
+    # @return [true,false] Based on validity of the specified platform
+    #
+    # @example:
+    #   is_valid = valid_platform?("sles-12-x86_64")
+    #
+    # TODO: validate for a specified version?
+    #
+    def self.valid_platform?(platform)
+      puts "Checking valid platforms: #{@pe_platforms}"
+      valid = @pe_platforms.include?(platform) ? true : false
+      puts "Platform #{platform} is valid" if valid
+      puts "Platform #{platform} is not valid" unless valid
+
+      return valid
+    end
+  end
+end

--- a/ref_arch_setup.gemspec
+++ b/ref_arch_setup.gemspec
@@ -15,12 +15,13 @@ Gem::Specification.new do |spec|
   # Ensure the gem is build out of the versioned files
   spec.files            = Dir["CONTRIBUTING.md", "LICENSE.md", "MAINTAINERS",
                               "README.md", "lib/**/*", "bin/*", "docs/**/*",
-                              "fixtures/**/*", "modules/**/*"]
+                              "fixtures/**/*", "modules/**/*", "Boltdir/**/*"]
   spec.executables   = ["ref_arch_setup"]
   spec.require_paths = ["lib"]
 
   # Run time dependencies
   spec.add_runtime_dependency "bolt", "~> 0.22.0"
+  spec.add_runtime_dependency "oga", "~> 2.15"
 
   # Development dependencies
   spec.add_development_dependency "beaker", "~>4.0"

--- a/spec/ref_arch_setup/download_helper_spec.rb
+++ b/spec/ref_arch_setup/download_helper_spec.rb
@@ -134,14 +134,17 @@ describe RefArchSetup::DownloadHelper do
     context "when environment variables are specified" do
       versions_url = "http://this.test.net.versions"
       base_url = "http://this.test.net.base"
+      min_version = "444.44.44"
 
       it "sets the expected properties to the specified values" do
         ENV["PE_VERSIONS_URL"] = versions_url
         ENV["BASE_PROD_URL"] = base_url
+        ENV["MIN_PROD_VERSION"] = min_version
         test_subject = RefArchSetup::DownloadHelper.new
 
         expect(test_subject.instance_variable_get(:@pe_versions_url)).to eq(versions_url)
         expect(test_subject.instance_variable_get(:@base_prod_url)).to eq(base_url)
+        expect(test_subject.instance_variable_get(:@min_prod_version)).to eq(min_version)
         expect(test_subject.instance_variable_get(:@pe_platforms)).to eq(subject::PE_PLATFORMS)
       end
     end
@@ -150,11 +153,14 @@ describe RefArchSetup::DownloadHelper do
       it "sets the properties to the default values" do
         ENV["PE_VERSIONS_URL"] = nil
         ENV["BASE_PROD_URL"] = nil
+        ENV["MIN_PROD_VERSION"] = nil
         test_subject = RefArchSetup::DownloadHelper.new
 
         expect(test_subject.instance_variable_get(:@pe_versions_url))
           .to eq(subject::PE_VERSIONS_URL)
         expect(test_subject.instance_variable_get(:@base_prod_url)).to eq(subject::BASE_PROD_URL)
+        expect(test_subject.instance_variable_get(:@min_prod_version))
+          .to eq(subject::MIN_PROD_VERSION)
         expect(test_subject.instance_variable_get(:@pe_platforms)).to eq(subject::PE_PLATFORMS)
       end
     end

--- a/spec/ref_arch_setup/download_helper_spec.rb
+++ b/spec/ref_arch_setup/download_helper_spec.rb
@@ -1,0 +1,927 @@
+require "spec_helper"
+require "json"
+
+describe RefArchSetup::DownloadHelper do
+  subject = RefArchSetup::DownloadHelper
+
+  let(:test_versions_result) { Class.new }
+  let(:test_pe_versions_uri) { Class.new }
+
+  TEST_PE_VERSIONS_URL = "http://testing.net/pe-versions".freeze
+  TEST_BASE_PROD_URL = "http://testing.net/pe-tarballs".freeze
+  TEST_LATEST_VERSION = "2077.1.4".freeze
+  TEST_OLDER_VERSION = "2076.3.10".freeze
+  TEST_EL6_PLATFORM = "el-66-x86_64".freeze
+  TEST_EL7_PLATFORM = "el-77-x86_64".freeze
+  TEST_SLES_PLATFORM = "sles-111-x86_64".freeze
+  TEST_UBUNTU_PLATFORM = "ubuntu-99.04-amd64".freeze
+  TEST_INVALID_PLATFORM = "ubuntu-333.04-amd64".freeze
+  TEST_PE_PLATFORMS = [TEST_EL6_PLATFORM,
+                       TEST_EL7_PLATFORM,
+                       TEST_SLES_PLATFORM,
+                       TEST_UBUNTU_PLATFORM].freeze
+  TEST_MIN_PROD_VERSION = "2076.1.0".freeze
+
+  TEST_VALID_RESPONSE_BODY = "OK".freeze
+  TEST_INVALID_RESPONSE_BODY = "".freeze
+  TEST_VALID_RESPONSE_CODE = "200".freeze
+  TEST_INVALID_RESPONSE_CODE = "777".freeze
+
+  TEST_CENTOS_OUTPUT = '[
+  {
+    "node": "my_host",
+    "status": "success",
+    "result": {
+      "os": {
+        "name": "CentOS",
+        "release": {
+          "full": "77.2",
+          "major": "77",
+          "minor": "2"
+        },
+        "family": "RedHat"
+      }
+    }
+  }
+]'.freeze
+
+  TEST_SLES_OUTPUT = '[
+  {
+    "node": "my_host",
+    "status": "success",
+    "result": {
+      "os": {
+        "name": "SLES",
+        "release": {
+          "full": "111.1",
+          "major": "111",
+          "minor": "2"
+        },
+        "family": "SLES"
+      }
+    }
+  }
+]'.freeze
+
+  TEST_UBUNTU_OUTPUT = '[
+  {
+    "node": "my_host",
+    "status": "success",
+    "result": {
+      "os": {
+        "name": "Ubuntu",
+        "release": {
+          "full": "99.04",
+          "major": "99",
+          "minor": "2"
+        },
+        "family": "Debian"
+      }
+    }
+  }
+]'.freeze
+
+  TEST_UNKNOWN_DEBIAN_OUTPUT = '[
+  {
+    "node": "my_host",
+    "status": "success",
+    "result": {
+      "os": {
+        "name": "SparkyLinux",
+        "release": {
+          "full": "1.1",
+          "major": "777",
+          "minor": "2"
+        },
+        "family": "Debian"
+      }
+    }
+  }
+]'.freeze
+
+  TEST_UNKNOWN_OUTPUT = '[
+  {
+    "node": "my_host",
+    "status": "success",
+    "result": {
+      "os": {
+        "name": "Gentoo",
+        "release": {
+          "full": "1.1",
+          "major": "111",
+          "minor": "2"
+        },
+        "family": "Gentoo"
+      }
+    }
+  }
+]'.freeze
+
+  TEST_CENTOS_FACTS = JSON.parse(TEST_CENTOS_OUTPUT)
+  TEST_SLES_FACTS = JSON.parse(TEST_SLES_OUTPUT)
+  TEST_UBUNTU_FACTS = JSON.parse(TEST_UBUNTU_OUTPUT)
+  TEST_UNKNOWN_DEBIAN_FACTS = JSON.parse(TEST_UNKNOWN_DEBIAN_OUTPUT)
+  TEST_UNKNOWN_FACTS = JSON.parse(TEST_UNKNOWN_OUTPUT)
+
+  before do
+    subject.instance_variable_set(:@pe_versions_url, TEST_PE_VERSIONS_URL)
+    subject.instance_variable_set(:@base_prod_url, TEST_BASE_PROD_URL)
+    subject.instance_variable_set(:@pe_platforms, TEST_PE_PLATFORMS)
+    subject.instance_variable_set(:@min_prod_version, TEST_MIN_PROD_VERSION)
+  end
+
+  describe "#initialize" do
+    context "when environment variables are specified" do
+      versions_url = "http://this.test.net.versions"
+      base_url = "http://this.test.net.base"
+
+      it "sets the expected properties to the specified values" do
+        ENV["PE_VERSIONS_URL"] = versions_url
+        ENV["BASE_PROD_URL"] = base_url
+        test_subject = RefArchSetup::DownloadHelper.new
+
+        expect(test_subject.instance_variable_get(:@pe_versions_url)).to eq(versions_url)
+        expect(test_subject.instance_variable_get(:@base_prod_url)).to eq(base_url)
+        expect(test_subject.instance_variable_get(:@pe_platforms)).to eq(subject::PE_PLATFORMS)
+      end
+    end
+
+    context "when environment variables are not specified" do
+      it "sets the properties to the default values" do
+        ENV["PE_VERSIONS_URL"] = nil
+        ENV["BASE_PROD_URL"] = nil
+        test_subject = RefArchSetup::DownloadHelper.new
+
+        expect(test_subject.instance_variable_get(:@pe_versions_url))
+          .to eq(subject::PE_VERSIONS_URL)
+        expect(test_subject.instance_variable_get(:@base_prod_url)).to eq(subject::BASE_PROD_URL)
+        expect(test_subject.instance_variable_get(:@pe_platforms)).to eq(subject::PE_PLATFORMS)
+      end
+    end
+  end
+
+  describe "#build_prod_tarball_url" do
+    context "when no arguments are specified" do
+      version = TEST_LATEST_VERSION
+      host = "localhost"
+      platform = "default"
+      pe_platform = TEST_EL7_PLATFORM
+      url = "#{TEST_BASE_PROD_URL}/#{version}/puppet-enterprise-#{version}-#{pe_platform}.tar.gz"
+
+      it "uses the default values" do
+        expect(subject).to receive(:handle_prod_version).with("latest").and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        allow(subject).to receive(:puts)
+        subject.build_prod_tarball_url
+      end
+
+      it "outputs the expected URL" do
+        expect(subject).to receive(:handle_prod_version).with("latest").and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        expect(subject).to receive(:puts).with("URL: #{url}")
+        subject.build_prod_tarball_url
+      end
+
+      it "returns the expected URL" do
+        expect(subject).to receive(:handle_prod_version).with("latest").and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        allow(subject).to receive(:puts)
+        expect(subject.build_prod_tarball_url).to eq(url)
+      end
+    end
+
+    context "when a version is specified" do
+      version = TEST_OLDER_VERSION
+      host = "localhost"
+      platform = "default"
+      pe_platform = TEST_EL7_PLATFORM
+      url = "#{TEST_BASE_PROD_URL}/#{version}/puppet-enterprise-#{version}-#{pe_platform}.tar.gz"
+
+      it "uses the specified version" do
+        expect(subject).to receive(:handle_prod_version).with(version).and_return(version)
+        expect(subject).to receive(:handle_platform)
+        allow(subject).to receive(:puts)
+        subject.build_prod_tarball_url(version)
+      end
+
+      it "gets the platform for localhost" do
+        expect(subject).to receive(:handle_prod_version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        allow(subject).to receive(:puts)
+        subject.build_prod_tarball_url(version)
+      end
+
+      it "outputs the expected URL" do
+        expect(subject).to receive(:handle_prod_version).with(version).and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        expect(subject).to receive(:puts).with("URL: #{url}")
+        subject.build_prod_tarball_url(version)
+      end
+
+      it "returns the expected URL" do
+        expect(subject).to receive(:handle_prod_version).with(version).and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        allow(subject).to receive(:puts)
+        expect(subject.build_prod_tarball_url(version)).to eq(url)
+      end
+    end
+
+    context "when a version and host are specified" do
+      version = TEST_OLDER_VERSION
+      host = "my_host"
+      platform = "default"
+      pe_platform = TEST_EL7_PLATFORM
+      url = "#{TEST_BASE_PROD_URL}/#{version}/puppet-enterprise-#{version}-#{pe_platform}.tar.gz"
+
+      it "uses the specified version" do
+        expect(subject).to receive(:handle_prod_version).with(version).and_return(version)
+        expect(subject).to receive(:handle_platform)
+        allow(subject).to receive(:puts)
+        subject.build_prod_tarball_url(version, host)
+      end
+
+      it "gets the platform for the specified host" do
+        expect(subject).to receive(:handle_prod_version).with(version).and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        allow(subject).to receive(:puts)
+        subject.build_prod_tarball_url(version, host)
+      end
+
+      it "outputs the expected URL" do
+        expect(subject).to receive(:handle_prod_version).with(version).and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        expect(subject).to receive(:puts).with("URL: #{url}")
+        subject.build_prod_tarball_url(version, host)
+      end
+
+      it "returns the expected URL" do
+        expect(subject).to receive(:handle_prod_version).with(version).and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        allow(subject).to receive(:puts)
+        expect(subject.build_prod_tarball_url(version, host)).to eq(url)
+      end
+    end
+
+    context "when all arguments are specified" do
+      version = TEST_OLDER_VERSION
+      host = "my_host"
+      platform = TEST_PE_PLATFORMS[3]
+      pe_platform = platform
+      url = "#{TEST_BASE_PROD_URL}/#{version}/puppet-enterprise-#{version}-#{pe_platform}.tar.gz"
+
+      it "uses the specified version and platform" do
+        expect(subject).to receive(:handle_prod_version).with(version).and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        allow(subject).to receive(:puts)
+        subject.build_prod_tarball_url(version, host, platform)
+      end
+
+      it "outputs the expected URL" do
+        expect(subject).to receive(:handle_prod_version).with(version).and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        expect(subject).to receive(:puts).with("URL: #{url}")
+        subject.build_prod_tarball_url(version, host, platform)
+      end
+
+      it "returns the expected URL" do
+        expect(subject).to receive(:handle_prod_version).with(version).and_return(version)
+        expect(subject).to receive(:handle_platform).with(host, platform).and_return(pe_platform)
+        allow(subject).to receive(:puts)
+        expect(subject.build_prod_tarball_url(version, host, platform)).to eq(url)
+      end
+    end
+  end
+
+  describe "#handle_prod_version" do
+    context "when the specified version is 'latest'" do
+      it "gets the latest prod version" do
+        version = "latest"
+        pe_version = TEST_LATEST_VERSION
+
+        expect(subject).to receive(:latest_prod_version).and_return(pe_version)
+        expect(subject).to receive(:puts).with("The latest version is: #{pe_version}")
+        expect(subject.handle_prod_version(version)).to eq(pe_version)
+      end
+    end
+
+    context "when the specified version is a valid version" do
+      it "returns the specified version" do
+        version = TEST_LATEST_VERSION
+        pe_version = TEST_LATEST_VERSION
+        message = "Using specified version: #{version}"
+
+        expect(subject).not_to receive(:latest_prod_version)
+        expect(subject).to receive(:ensure_valid_prod_version).with(version).and_return(true)
+        expect(subject).to receive(:ensure_supported_prod_version).with(version).and_return(true)
+        expect(subject).to receive(:puts).with(message)
+        expect(subject.handle_prod_version(version)).to eq(pe_version)
+      end
+    end
+
+    context "when the specified version is not a valid version" do
+      it "raises an error" do
+        version = "1.2.3"
+        error = "Invalid version: #{version}"
+
+        expect(subject).not_to receive(:latest_prod_version)
+        expect(subject).to receive(:ensure_valid_prod_version).with(version).and_return(false)
+        expect(subject).not_to receive(:puts).with("Using specified version: #{version}")
+        expect { subject.handle_prod_version(version) }.to raise_error(RuntimeError, error)
+      end
+    end
+  end
+
+  describe "#latest_prod_version" do
+    context "when called" do
+      it "returns the first version from the prod versions list" do
+        expect(subject).to receive(:parse_prod_versions_url).and_return(test_versions_result)
+        expect(test_versions_result).to receive(:text).and_return(TEST_LATEST_VERSION)
+        expect(subject.latest_prod_version).to eq(TEST_LATEST_VERSION)
+      end
+    end
+  end
+
+  describe "#ensure_valid_prod_version" do
+    context "when the specified version is found" do
+      version = TEST_LATEST_VERSION
+      message = "Verifying specified PE version: #{version}"
+
+      it "outputs helpful messages" do
+        result = "Specified version #{version} was found"
+
+        expect(subject).to receive(:parse_prod_versions_url).and_return(test_versions_result)
+        expect(subject).to receive(:puts).with(message)
+        expect(subject).to receive(:puts).with(result)
+
+        expect(test_versions_result).to receive(:text).and_return(version)
+        subject.ensure_valid_prod_version(version)
+      end
+
+      it "returns true" do
+        expect(subject).to receive(:parse_prod_versions_url).and_return(test_versions_result)
+        expect(test_versions_result).to receive(:text).and_return(version)
+        allow(subject).to receive(:puts)
+        expect(subject.ensure_valid_prod_version(version)).to eq(true)
+      end
+    end
+
+    context "when the specified version is not found" do
+      version = "x.y.z"
+      message = "Verifying specified PE version: #{version}"
+
+      it "outputs only the expected messages (and raises an error)" do
+        result = "Specified version #{version} was not found"
+
+        expect(subject).to receive(:parse_prod_versions_url).and_return(test_versions_result)
+        expect(subject).to receive(:puts).with(message)
+        expect(subject).not_to receive(:puts).with(result)
+
+        expect(test_versions_result).to receive(:text).and_return("")
+        expect { subject.ensure_valid_prod_version(version) }.to raise_error(RuntimeError)
+      end
+
+      it "raises the expected error" do
+        error = "Specified version not found: #{version}"
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:parse_prod_versions_url).and_return(test_versions_result)
+        expect(test_versions_result).to receive(:text).and_return("")
+        expect { subject.ensure_valid_prod_version(version) }.to raise_error(RuntimeError, error)
+      end
+    end
+  end
+
+  describe "#ensure_supported_prod_version" do
+    context "when the version is supported" do
+      version = "2018.1.4"
+      message = "Specified version #{version} is supported by RAS"
+
+      it "outputs a confirmation" do
+        expect(subject).to receive(:puts).with(message)
+        subject.ensure_supported_prod_version(version)
+      end
+
+      it "returns true" do
+        allow(subject).to receive(:puts)
+        expect(subject.ensure_supported_prod_version(version)).to eq(true)
+      end
+    end
+
+    context "when the version is not supported" do
+      version = "2017.1.4"
+      message = "The minimum supported version is #{subject::MIN_PROD_VERSION}"
+      error = "Specified version #{version} is not supported by RAS"
+
+      it "outputs an explanation (and raises an error)" do
+        expect(subject).to receive(:puts).with(message)
+        expect { subject.ensure_supported_prod_version(version) }
+          .to raise_error(RuntimeError)
+      end
+
+      it "raises the expected error" do
+        allow(subject).to receive(:puts)
+        expect { subject.ensure_supported_prod_version(version) }
+          .to raise_error(RuntimeError, error)
+      end
+    end
+  end
+
+  describe "#fetch_prod_versions" do
+    context "when called" do
+      it "returns the default result from parse_prod_versions_url" do
+        expect(subject).to receive(:parse_prod_versions_url).and_return(test_versions_result)
+        expect(subject.fetch_prod_versions).to eq(test_versions_result)
+      end
+    end
+  end
+
+  describe "#parse_prod_versions_url" do
+    let(:test_net_http) { Class.new }
+    let(:test_uri) { Class.new }
+    let(:test_oga) { Class.new }
+
+    let(:test_http_response) { Class.new }
+    let(:test_body) { Class.new }
+    let(:test_document) { Class.new }
+    let(:test_result) { Class.new }
+
+    message = "Checking Puppet Enterprise Version History: #{TEST_PE_VERSIONS_URL}"
+
+    before do
+      stub_const("Net::HTTP", test_net_http)
+      stub_const("URI", test_uri)
+      stub_const("Oga", test_oga)
+    end
+
+    context "when the response is valid" do
+      context "when an xpath is specified" do
+        it "uses the specified xpath and returns the result" do
+          xpath = "//table/tbody/tr[1]/td[1]"
+
+          expect(subject).to receive(:puts).with(message)
+
+          expect(test_uri).to receive(:parse)
+            .with(TEST_PE_VERSIONS_URL).and_return(test_pe_versions_uri)
+
+          expect(test_net_http).to receive(:get_response)
+            .with(test_pe_versions_uri).and_return(test_http_response)
+
+          expect(subject).to receive(:valid_response?)
+            .with(test_http_response).and_return(true)
+
+          expect(test_http_response).to receive(:body).and_return(test_body)
+
+          expect(test_oga).to receive(:parse_html)
+            .with(test_body).and_return(test_document)
+
+          expect(test_document).to receive(:xpath)
+            .with(xpath).and_return(test_result)
+
+          expect(subject.parse_prod_versions_url(xpath)).to eq(test_result)
+        end
+      end
+
+      context "when an xpath is not specified" do
+        it "uses the default xpath and returns the versions" do
+          xpath = "//table/tbody/tr/td[1]"
+
+          expect(subject).to receive(:puts).with(message)
+
+          expect(test_uri).to receive(:parse)
+            .with(TEST_PE_VERSIONS_URL).and_return(test_pe_versions_uri)
+
+          expect(test_net_http).to receive(:get_response)
+            .with(test_pe_versions_uri).and_return(test_http_response)
+
+          expect(subject).to receive(:valid_response?)
+            .with(test_http_response).and_return(true)
+
+          expect(test_http_response).to receive(:body).and_return(test_body)
+
+          expect(test_oga).to receive(:parse_html)
+            .with(test_body).and_return(test_document)
+
+          expect(test_document).to receive(:xpath)
+            .with(xpath).and_return(test_result)
+
+          expect(subject.parse_prod_versions_url).to eq(test_result)
+        end
+      end
+    end
+
+    context "when the response is not valid" do
+      it "raises an error" do
+        error = "Invalid response"
+
+        expect(subject).to receive(:puts).with(message)
+
+        expect(test_uri).to receive(:parse)
+          .with(TEST_PE_VERSIONS_URL).and_return(test_pe_versions_uri)
+
+        expect(test_net_http).to receive(:get_response)
+          .with(test_pe_versions_uri).and_return(test_http_response)
+
+        expect(subject).to receive(:valid_response?)
+          .with(test_http_response).and_return(false)
+
+        expect(test_http_response).not_to receive(:body)
+
+        expect { subject.parse_prod_versions_url }.to raise_error(RuntimeError, error)
+      end
+    end
+  end
+
+  describe "#valid_response?" do
+    let(:test_http_response) { Class.new }
+
+    context "when a valid response is provided" do
+      code = TEST_VALID_RESPONSE_CODE
+      body = TEST_VALID_RESPONSE_BODY
+
+      it "returns true" do
+        expect(test_http_response).to receive(:nil?).and_return(false)
+        expect(test_http_response).to receive(:code).and_return(code)
+        expect(test_http_response).to receive(:body).and_return(body)
+
+        expect(subject.valid_response?(test_http_response)).to eq(true)
+      end
+    end
+
+    context "when the response is nil" do
+      it "reports the error" do
+        error = "Invalid response:"
+        expect(subject).to receive(:puts).with(error)
+        expect(subject).to receive(:puts).with(no_args)
+        subject.valid_response?(nil)
+      end
+
+      it "returns false" do
+        allow(subject).to receive(:puts)
+        expect(subject.valid_response?(nil)).to eq(false)
+      end
+    end
+
+    context "when the response code is not valid" do
+      code = TEST_INVALID_RESPONSE_CODE
+      body = TEST_VALID_RESPONSE_BODY
+      error = "Invalid response:"
+      code_message = "code: #{code}"
+      body_message = "body: #{body}"
+
+      it "reports the error" do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(code)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(body)
+
+        expect(subject).to receive(:puts).with(error)
+        expect(subject).to receive(:puts).with(code_message)
+        expect(subject).to receive(:puts).with(body_message)
+        expect(subject).to receive(:puts).with(no_args)
+
+        subject.valid_response?(test_http_response)
+      end
+
+      it "returns false" do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(code)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(body)
+
+        allow(subject).to receive(:puts)
+        expect(subject.valid_response?(test_http_response)).to eq(false)
+      end
+    end
+
+    context "when the response body is empty" do
+      code = TEST_VALID_RESPONSE_CODE
+      body = TEST_INVALID_RESPONSE_BODY
+      error = "Invalid response:"
+      code_message = "code: #{code}"
+      body_message = "body: #{body}"
+
+      it "reports the error" do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(code)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(body)
+
+        expect(subject).to receive(:puts).with(error)
+        expect(subject).to receive(:puts).with(code_message)
+        expect(subject).to receive(:puts).with(body_message)
+        expect(subject).to receive(:puts).with(no_args)
+
+        subject.valid_response?(test_http_response)
+      end
+
+      it "returns false" do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(code)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(body)
+
+        allow(subject).to receive(:puts)
+
+        expect(subject.valid_response?(test_http_response)).to eq(false)
+      end
+    end
+
+    context "when the response body is nil" do
+      code = TEST_VALID_RESPONSE_CODE
+      body = nil
+      error = "Invalid response:"
+      code_message = "code: #{code}"
+      body_message = "body: #{body}"
+
+      it "reports the error" do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(code)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(body)
+
+        expect(subject).to receive(:puts).with(error)
+        expect(subject).to receive(:puts).with(code_message)
+        expect(subject).to receive(:puts).with(body_message)
+        expect(subject).to receive(:puts).with(no_args)
+
+        subject.valid_response?(test_http_response)
+      end
+
+      it "returns false" do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(code)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(body)
+
+        allow(subject).to receive(:puts)
+
+        expect(subject.valid_response?(test_http_response)).to eq(false)
+      end
+    end
+  end
+
+  describe "#handle_platform" do
+    context "when platform is 'default'" do
+      context "when the host platform is valid" do
+        host = "my_host"
+        platform = "default"
+        pe_platform = TEST_EL7_PLATFORM
+
+        it "outputs the expected message" do
+          expect(subject).to receive(:puts)
+            .with("Default platform specified; determining platform for host")
+
+          expect(subject).to receive(:handle_platform_for_host)
+            .with(host).and_return(pe_platform)
+
+          expect(subject).not_to receive(:puts).with("Specified platform: #{pe_platform}")
+
+          expect(subject).to receive(:valid_platform?)
+            .with(pe_platform).and_return(true)
+
+          subject.handle_platform(host, platform)
+        end
+
+        it "returns the validated platform for the specified host" do
+          allow(subject).to receive(:puts)
+
+          expect(subject).to receive(:handle_platform_for_host)
+            .with(host).and_return(pe_platform)
+
+          expect(subject).to receive(:valid_platform?)
+            .with(pe_platform).and_return(true)
+
+          expect(subject.handle_platform(host, platform)).to eq(pe_platform)
+        end
+      end
+
+      context "when the host platform is not valid" do
+        host = "my_host"
+        platform = "default"
+        pe_platform = TEST_EL7_PLATFORM
+        error = "Invalid PE platform: #{pe_platform}"
+        it "outputs the expected message (and raises an error)" do
+          expect(subject).to receive(:puts)
+            .with("Default platform specified; determining platform for host")
+
+          expect(subject).to receive(:handle_platform_for_host)
+            .with(host).and_return(pe_platform)
+
+          expect(subject).not_to receive(:puts).with("Specified platform: #{pe_platform}")
+
+          expect(subject).to receive(:valid_platform?)
+            .with(pe_platform).and_return(false)
+
+          expect { subject.handle_platform(host, platform) }
+            .to raise_error(RuntimeError)
+        end
+
+        it "raises the expected error" do
+          allow(subject).to receive(:puts)
+
+          expect(subject).to receive(:handle_platform_for_host)
+            .with(host).and_return(pe_platform)
+
+          expect(subject).to receive(:valid_platform?)
+            .with(pe_platform).and_return(false)
+
+          expect { subject.handle_platform(host, platform) }
+            .to raise_error(RuntimeError, error)
+        end
+      end
+    end
+
+    context "when the platform is not 'default'" do
+      context "when the platform is a valid PE platform" do
+        host = "my_host"
+        platform = TEST_SLES_PLATFORM
+        pe_platform = platform
+
+        it "successfully validates the specified platform" do
+          expect(subject).not_to receive(:puts)
+            .with("Default platform specified; determining platform for host")
+
+          expect(subject).not_to receive(:handle_platform_for_host).with(host)
+          expect(subject).not_to receive(:puts).with("platform: #{pe_platform}")
+
+          expect(subject).to receive(:puts).with("Specified platform: #{pe_platform}")
+          expect(subject).to receive(:valid_platform?).with(pe_platform).and_return(true)
+
+          expect(subject.handle_platform(host, platform)).to eq(pe_platform)
+        end
+      end
+
+      context "when the platform is not a valid PE platform" do
+        host = "my_host"
+        platform = "invalid_platform"
+        pe_platform = platform
+        error = "Invalid PE platform: #{pe_platform}"
+
+        it "outputs the expected message (and raises an error)" do
+          expect(subject).not_to receive(:puts)
+            .with("Default platform specified; determining platform for host")
+          expect(subject).not_to receive(:handle_platform_for_host).with(host)
+          expect(subject).not_to receive(:puts).with("platform: #{pe_platform}")
+
+          expect(subject).to receive(:puts).with("Specified platform: #{pe_platform}")
+
+          expect(subject).to receive(:valid_platform?)
+            .with(pe_platform).and_return(false)
+
+          expect { subject.handle_platform(host, platform) }
+            .to raise_error(RuntimeError)
+        end
+
+        it "raises the expected error" do
+          allow(subject).to receive(:puts)
+          expect(subject).to receive(:valid_platform?)
+            .with(pe_platform).and_return(false)
+
+          expect { subject.handle_platform(host, platform) }
+            .to raise_error(RuntimeError, error)
+        end
+      end
+    end
+  end
+
+  describe "#handle_platform_for_host" do
+    context "when the host os family is RedHat" do
+      it "returns the correct platform string" do
+        host = "my_host"
+        pe_platform = TEST_EL7_PLATFORM
+        message = "Host platform: #{pe_platform}"
+
+        expect(subject).to receive(:retrieve_facts)
+          .with(host).and_return(TEST_CENTOS_FACTS)
+        expect(subject).to receive(:puts).with(message)
+        expect(subject.handle_platform_for_host(host)).to eq(pe_platform)
+      end
+    end
+
+    context "when the host os family is SLES" do
+      it "returns the correct platform string" do
+        host = "my_host"
+        pe_platform = TEST_SLES_PLATFORM
+        message = "Host platform: #{pe_platform}"
+
+        expect(subject).to receive(:retrieve_facts)
+          .with(host).and_return(TEST_SLES_FACTS)
+        expect(subject).to receive(:puts).with(message)
+        expect(subject.handle_platform_for_host(host)).to eq(pe_platform)
+      end
+    end
+
+    context "when the host os family is Debian" do
+      context "when the host os name is Ubuntu" do
+        it "returns the correct platform string" do
+          host = "my_host"
+          pe_platform = TEST_UBUNTU_PLATFORM
+          message = "Host platform: #{pe_platform}"
+
+          expect(subject).to receive(:retrieve_facts)
+            .with(host).and_return(TEST_UBUNTU_FACTS)
+          expect(subject).to receive(:puts).with(message)
+          expect(subject.handle_platform_for_host(host)).to eq(pe_platform)
+        end
+      end
+
+      context "when the host os name is not Ubuntu" do
+        it "raises an error" do
+          host = "my_host"
+          error = "Unable to determine platform for host: #{host}"
+
+          expect(subject).to receive(:retrieve_facts)
+            .with(host).and_return(TEST_UNKNOWN_DEBIAN_FACTS)
+
+          expect { subject.handle_platform_for_host(host) }
+            .to raise_error(RuntimeError, error)
+        end
+      end
+
+      context "when the host os family is not recognized " do
+        it "raises an error" do
+          host = "my_host"
+          error = "Unable to determine platform for host: #{host}"
+
+          expect(subject).to receive(:retrieve_facts)
+            .with(host).and_return(TEST_UNKNOWN_FACTS)
+
+          expect { subject.handle_platform_for_host(host) }
+            .to raise_error(RuntimeError, error)
+        end
+      end
+    end
+  end
+
+  # TODO: separate test cases
+  describe "#retrieve_facts" do
+    plan = "facts::retrieve"
+    hosts = "my_host"
+    message = "Retrieving facts for hosts: #{hosts}"
+
+    context "when bolt successfully runs the facts plan" do
+      output = TEST_CENTOS_OUTPUT
+      facts = TEST_CENTOS_FACTS
+
+      it "returns the facts" do
+        expect(subject).to receive(:puts).with(message)
+        expect(RefArchSetup::BoltHelper).to receive(:run_forge_plan_with_bolt)
+          .with(plan, nil, hosts).and_return(output)
+        expect(JSON).to receive(:parse)
+          .with(output).and_return(facts)
+
+        expect(subject.retrieve_facts(hosts)).to eq(facts)
+      end
+    end
+
+    context "when bolt is not able to successfully run the facts plan" do
+      context "when the output can't be parsed" do
+        it "outputs a helpful message and re-raises the error" do
+          invalid_output = "123"
+          helpful_message = "Unable to parse bolt output"
+          error_message = "JSON parse error"
+          expect(subject).to receive(:puts).with(message)
+          expect(RefArchSetup::BoltHelper).to receive(:run_forge_plan_with_bolt)
+            .with(plan, nil, hosts).and_return(invalid_output)
+          expect(JSON).to receive(:parse)
+            .with(invalid_output).and_raise(RuntimeError, error_message)
+          expect(subject).to receive(:puts).with(helpful_message)
+
+          expect { subject.retrieve_facts(hosts) }
+            .to raise_error(RuntimeError, error_message)
+        end
+      end
+    end
+  end
+
+  describe "#valid_platform?" do
+    message = "Checking valid platforms: #{TEST_PE_PLATFORMS}"
+
+    context "when the platform is included in the list of valid platforms" do
+      platform = TEST_UBUNTU_PLATFORM
+      result = "Platform #{platform} is valid"
+
+      it "outputs the expected messages" do
+        expect(subject).to receive(:puts).with(message)
+        expect(subject).to receive(:puts).with(result)
+
+        subject.valid_platform?(platform)
+      end
+
+      it "returns true" do
+        allow(subject).to receive(:puts)
+        expect(subject.valid_platform?(platform)).to eq(true)
+      end
+    end
+
+    context "when the platform is not included in the list of valid platforms" do
+      platform = TEST_INVALID_PLATFORM
+      result = "Platform #{platform} is not valid"
+
+      it "outputs the expected messages" do
+        expect(subject).to receive(:puts).with(message)
+        expect(subject).to receive(:puts).with(result)
+
+        subject.valid_platform?(platform)
+      end
+
+      it "returns false" do
+        allow(subject).to receive(:puts)
+        expect(subject.valid_platform?(platform)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This update adds download_helper.rb which provides the `build_prod_tarball_url` method. 