### PR TITLE
(SLV-155) Update bootstrap to handle --pe-version inputs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require "fileutils"
 require "rototiller"
 require "./gem_of/lib/gem_of/rake_tasks"
 require "./acceptance/helpers/beaker_helper"
-require "./lib/ref_arch_setup/bolt_helper.rb"
+require "./lib/ref_arch_setup.rb"
 
 include BeakerHelper
 
@@ -41,7 +41,6 @@ namespace :test do
   desc "Run acceptance test using Beaker subcommands"
   task :acceptance do
     beaker_initialize
-    Rake::Task["bolt:install_forge_modules"].execute
     Rake::Task["gem:build"].execute
     Rake::Task["test:acceptance_init"].execute
     Rake::Task["test:acceptance_provision"].execute

--- a/acceptance/config/options.rb
+++ b/acceptance/config/options.rb
@@ -22,12 +22,13 @@
     "acceptance/pre_suites/40_download_pe_tarball.rb"
   ],
   :tests => [
-    "acceptance/tests/10_install_test_remote_master_tarball_url.rb",
-    "acceptance/tests/20_install_test_remote_master_tarball_path_controller.rb",
-    "acceptance/tests/30_install_test_remote_master_tarball_path_master.rb",
-    "acceptance/tests/40_install_test_local_master_tarball_url.rb",
-    "acceptance/tests/50_install_test_local_master_tarball_path.rb"
-
+    "acceptance/tests/110_install_test_remote_master_tarball_url.rb",
+    "acceptance/tests/120_install_test_remote_master_tarball_path_controller.rb",
+    "acceptance/tests/130_install_test_remote_master_tarball_path_master.rb",
+    "acceptance/tests/140_install_test_remote_master_version_latest.rb",
+    "acceptance/tests/150_install_test_remote_master_version_number.rb",
+    "acceptance/tests/210_install_test_local_master_tarball_url.rb",
+    "acceptance/tests/220_install_test_local_master_tarball_path.rb"
   ],
   "is_puppetserver"            => true,
   "use-service"                => true, # use service scripts to start/stop stuff

--- a/acceptance/helpers/beaker_helper.rb
+++ b/acceptance/helpers/beaker_helper.rb
@@ -7,10 +7,10 @@ module BeakerHelper
   LAYOUT = ENV["BEAKER_LAYOUT"] || "centos7-64controller.-64target_master.".freeze
   FORGE_HOST = ENV["BEAKER_FORGE_HOST"] || "forge-aio01-petest.puppetlabs.com".freeze
   PE_TARBALL_EXTENSION = ENV["BEAKER_PE_TARBALL_EXTENSION"] || ".tar".freeze
-  RAS_PATH = "$HOME/ref_arch_setup".freeze
-  RAS_FIXTURES_PATH = "#{RAS_PATH}/fixtures".freeze
-  RAS_MODULES_PATH = "#{RAS_PATH}/modules".freeze
-  RAS_PE_CONF = "#{RAS_FIXTURES_PATH}/pe.conf".freeze
+  BEAKER_RAS_PATH = "$HOME/ref_arch_setup".freeze
+  BEAKER_RAS_FIXTURES_PATH = "#{BEAKER_RAS_PATH}/fixtures".freeze
+  BEAKER_RAS_MODULES_PATH = "#{BEAKER_RAS_PATH}/modules".freeze
+  BEAKER_RAS_PE_CONF = "#{BEAKER_RAS_FIXTURES_PATH}/pe.conf".freeze
   RAS_TMP_WORK_DIR = "/tmp/ref_arch_setup".freeze
 
   # Initializes the PE instance variables

--- a/acceptance/pre_suites/25_install_gems.rb
+++ b/acceptance/pre_suites/25_install_gems.rb
@@ -1,4 +1,4 @@
-test_name "install bolt and gem-path on controller" do
+test_name "install required gems on controller" do
   # gem path is used to find ras
   step "install gem-path" do
     on controller, "gem install gem-path"

--- a/acceptance/pre_suites/30_setup_ras.rb
+++ b/acceptance/pre_suites/30_setup_ras.rb
@@ -1,19 +1,19 @@
 test_name "install RAS on controller" do
-  step "copy RAS gem" do
+  step "copy RAS gem to controller" do
     scp_to(controller, "#{__dir__}/../../pkg", "ref_arch_setup")
   end
 
   step "install RAS on controller" do
     version = RefArchSetup::Version::STRING
     gem = "ref_arch_setup-#{version}.gem"
-    command = "gem install #{RAS_PATH}/#{gem}"
+    command = "gem install #{BEAKER_RAS_PATH}/#{gem}"
 
     on controller, command
   end
 
   step "copy fixtures and modules" do
     ras_gem_path = get_ras_gem_path(controller)
-    on controller, "cp -r #{ras_gem_path}/fixtures #{RAS_PATH}"
-    on controller, "cp -r #{ras_gem_path}/modules #{RAS_PATH}"
+    on controller, "cp -r #{ras_gem_path}/fixtures #{BEAKER_RAS_PATH}"
+    on controller, "cp -r #{ras_gem_path}/modules #{BEAKER_RAS_PATH}"
   end
 end

--- a/acceptance/pre_suites/40_download_pe_tarball.rb
+++ b/acceptance/pre_suites/40_download_pe_tarball.rb
@@ -4,8 +4,8 @@ test_name "download PE tarball" do
     bolt = "bolt task run"
     task = "ref_arch_setup::download_pe_tarball"
     url = "url=#{pe_url}"
-    destination = "destination=#{RAS_PATH}"
-    modulepath = "--modulepath #{RAS_MODULES_PATH}"
+    destination = "destination=#{BEAKER_RAS_PATH}"
+    modulepath = "--modulepath #{BEAKER_RAS_MODULES_PATH}"
     nodes = "--nodes localhost,#{target_master}"
     user = "--user root"
 

--- a/acceptance/tests/110_install_test_remote_master_tarball_url.rb
+++ b/acceptance/tests/110_install_test_remote_master_tarball_url.rb
@@ -1,9 +1,9 @@
-test_name "perform install on remote master with tarball path on controller" do
+test_name "perform install on remote master with tarball url" do
   step "perform install" do
-    filename = get_pe_tarball_filename(target_master)
+    pe_url = get_pe_tarball_url(target_master)
     primary_master = "--primary-master=#{target_master}"
-    pe_tarball = "--pe-tarball=#{RAS_PATH}/#{filename}"
-    pe_conf = "--pe-conf=#{RAS_PE_CONF}"
+    pe_tarball = "--pe-tarball=#{pe_url}"
+    pe_conf = "--pe-conf=#{BEAKER_RAS_PE_CONF}"
     command = "ref_arch_setup install #{primary_master} #{pe_tarball} #{pe_conf}"
 
     puts command

--- a/acceptance/tests/120_install_test_remote_master_tarball_path_controller.rb
+++ b/acceptance/tests/120_install_test_remote_master_tarball_path_controller.rb
@@ -1,9 +1,9 @@
-test_name "perform install on remote master with tarball path on master" do
+test_name "perform install on remote master with tarball path on controller" do
   step "perform install" do
     filename = get_pe_tarball_filename(target_master)
     primary_master = "--primary-master=#{target_master}"
-    pe_tarball = "--pe-tarball=#{target_master}:#{RAS_PATH}/#{filename}"
-    pe_conf = "--pe-conf=#{RAS_PE_CONF}"
+    pe_tarball = "--pe-tarball=#{BEAKER_RAS_PATH}/#{filename}"
+    pe_conf = "--pe-conf=#{BEAKER_RAS_PE_CONF}"
     command = "ref_arch_setup install #{primary_master} #{pe_tarball} #{pe_conf}"
 
     puts command

--- a/acceptance/tests/130_install_test_remote_master_tarball_path_master.rb
+++ b/acceptance/tests/130_install_test_remote_master_tarball_path_master.rb
@@ -1,9 +1,9 @@
-test_name "perform install on remote master with tarball url" do
+test_name "perform install on remote master with tarball path on master" do
   step "perform install" do
-    pe_url = get_pe_tarball_url(target_master)
+    filename = get_pe_tarball_filename(target_master)
     primary_master = "--primary-master=#{target_master}"
-    pe_tarball = "--pe-tarball=#{pe_url}"
-    pe_conf = "--pe-conf=#{RAS_PE_CONF}"
+    pe_tarball = "--pe-tarball=#{target_master}:#{BEAKER_RAS_PATH}/#{filename}"
+    pe_conf = "--pe-conf=#{BEAKER_RAS_PE_CONF}"
     command = "ref_arch_setup install #{primary_master} #{pe_tarball} #{pe_conf}"
 
     puts command

--- a/acceptance/tests/140_install_test_remote_master_version_latest.rb
+++ b/acceptance/tests/140_install_test_remote_master_version_latest.rb
@@ -1,0 +1,19 @@
+test_name "perform install on remote master with latest version" do
+  step "perform install" do
+    pe_version = "--pe_version=latest"
+    primary_master = "--primary-master=#{target_master}"
+    pe_conf = "--pe-conf=#{BEAKER_RAS_PE_CONF}"
+    command = "ref_arch_setup install #{primary_master} #{pe_conf} #{pe_version}"
+
+    puts command
+    on controller, command
+  end
+
+  step "run puppet agent" do
+    on target_master, "puppet agent -t"
+  end
+
+  teardown do
+    ras_teardown(target_master)
+  end
+end

--- a/acceptance/tests/150_install_test_remote_master_version_number.rb
+++ b/acceptance/tests/150_install_test_remote_master_version_number.rb
@@ -1,0 +1,19 @@
+test_name "perform install on remote master with specified version" do
+  step "perform install" do
+    pe_version = "--pe_version=2018.1.4"
+    primary_master = "--primary-master=#{target_master}"
+    pe_conf = "--pe-conf=#{BEAKER_RAS_PE_CONF}"
+    command = "ref_arch_setup install #{primary_master} #{pe_conf} #{pe_version}"
+
+    puts command
+    on controller, command
+  end
+
+  step "run puppet agent" do
+    on target_master, "puppet agent -t"
+  end
+
+  teardown do
+    ras_teardown(target_master)
+  end
+end

--- a/acceptance/tests/210_install_test_local_master_tarball_url.rb
+++ b/acceptance/tests/210_install_test_local_master_tarball_url.rb
@@ -1,9 +1,9 @@
-test_name "perform install on local master with tarball path" do
+test_name "perform install on local master with tarball url" do
   step "perform install" do
-    filename = get_pe_tarball_filename(controller)
+    pe_url = get_pe_tarball_url(controller)
     primary_master = "--primary-master=localhost"
-    pe_tarball = "--pe-tarball=#{RAS_PATH}/#{filename}"
-    pe_conf = "--pe-conf=#{RAS_PE_CONF}"
+    pe_tarball = "--pe-tarball=#{pe_url}"
+    pe_conf = "--pe-conf=#{BEAKER_RAS_PE_CONF}"
     command = "ref_arch_setup install #{primary_master} #{pe_tarball} #{pe_conf}"
 
     puts command

--- a/acceptance/tests/220_install_test_local_master_tarball_path.rb
+++ b/acceptance/tests/220_install_test_local_master_tarball_path.rb
@@ -1,9 +1,9 @@
-test_name "perform install on local master with tarball url" do
+test_name "perform install on local master with tarball path" do
   step "perform install" do
-    pe_url = get_pe_tarball_url(controller)
+    filename = get_pe_tarball_filename(controller)
     primary_master = "--primary-master=localhost"
-    pe_tarball = "--pe-tarball=#{pe_url}"
-    pe_conf = "--pe-conf=#{RAS_PE_CONF}"
+    pe_tarball = "--pe-tarball=#{BEAKER_RAS_PATH}/#{filename}"
+    pe_conf = "--pe-conf=#{BEAKER_RAS_PE_CONF}"
     command = "ref_arch_setup install #{primary_master} #{pe_tarball} #{pe_conf}"
 
     puts command

--- a/lib/ref_arch_setup.rb
+++ b/lib/ref_arch_setup.rb
@@ -3,8 +3,12 @@ module RefArchSetup
   %w[cli bolt_helper download_helper version install].each do |lib|
     require "ref_arch_setup/#{lib}"
   end
+  # the location of ref_arch_setup
+  RAS_PATH = File.dirname(__FILE__) + "/.."
   # location of modules shipped with RAS (Ref Arch Setup)
-  RAS_MODULE_PATH = File.dirname(__FILE__) + "/../modules"
+  RAS_MODULE_PATH = "#{RAS_PATH}/modules"
   # location of fixtures shipped with RAS (Ref Arch Setup)
-  RAS_FIXTURES_PATH = File.dirname(__FILE__) + "/../fixtures"
+  RAS_FIXTURES_PATH = "#{RAS_PATH}/fixtures"
+  # location of modules downloaded from the Puppet Forge
+  FORGE_MODULE_PATH = "#{RAS_PATH}/Boltdir/modules"
 end

--- a/lib/ref_arch_setup.rb
+++ b/lib/ref_arch_setup.rb
@@ -4,11 +4,11 @@ module RefArchSetup
     require "ref_arch_setup/#{lib}"
   end
   # the location of ref_arch_setup
-  RAS_PATH = File.dirname(__FILE__) + "/.."
+  RAS_PATH = File.dirname(__FILE__) + "/..".freeze
   # location of modules shipped with RAS (Ref Arch Setup)
-  RAS_MODULE_PATH = "#{RAS_PATH}/modules"
+  RAS_MODULE_PATH = "#{RAS_PATH}/modules".freeze
   # location of fixtures shipped with RAS (Ref Arch Setup)
-  RAS_FIXTURES_PATH = "#{RAS_PATH}/fixtures"
+  RAS_FIXTURES_PATH = "#{RAS_PATH}/fixtures".freeze
   # location of modules downloaded from the Puppet Forge
-  FORGE_MODULE_PATH = "#{RAS_PATH}/Boltdir/modules"
+  FORGE_MODULE_PATH = "#{RAS_PATH}/Boltdir/modules".freeze
 end

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 # General namespace for RAS
 module RefArchSetup
   # Bolt helper methods
@@ -49,7 +48,7 @@ module RefArchSetup
       bolt_options(options_hash)
     end
 
-    # gets the bolt options as a string
+    # Gets the bolt options as a string
     #
     # @author Sam Woods
     # @return [string] the string value for bolt options
@@ -78,6 +77,27 @@ module RefArchSetup
       return success
     end
 
+    # Run the specified command
+    #
+    # @author Bill Claytor
+    #
+    # @param command [string] The command to run
+    # @param error_message [string] The error to raise if the command is not successful
+    #
+    # @return [string] The output returned from the command
+    def self.run_command(command, error_message = "ERROR: command failed!")
+      puts "Running: #{command}"
+      output = `#{command}`
+      puts "Output was: #{output}"
+
+      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
+      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
+      puts
+
+      raise error_message unless success
+      return output
+    end
+
     # Run a command with bolt on given nodes
     #
     # @author Randell Pelak
@@ -90,13 +110,9 @@ module RefArchSetup
       command = "bolt command run '#{cmd}'"
       command << " --nodes #{nodes}"
       command << bolt_options_string
-      puts "Running: #{command}"
-      output = `#{command}`
-      puts "Output was: #{output}"
 
-      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
-      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
-      raise "ERROR: bolt command failed!" unless success
+      output = run_command(command, "ERROR: bolt command failed!")
+      success = true unless output.nil?
 
       return success
     end
@@ -117,13 +133,9 @@ module RefArchSetup
       command = "bolt task run #{task} #{params_str}"
       command << " --modulepath #{modulepath} --nodes #{nodes}"
       command << bolt_options_string
-      puts "Running: #{command}"
-      output = `#{command}`
-      puts "Output was: #{output}"
 
-      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
-      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
-      raise "ERROR: bolt task failed!" unless success
+      output = run_command(command, "ERROR: bolt task failed!")
+      success = true unless output.nil?
 
       return success
     end
@@ -144,13 +156,8 @@ module RefArchSetup
       command = "bolt plan run #{plan} #{params_str}"
       command << " --modulepath #{modulepath} --nodes #{nodes}"
       command << bolt_options_string
-      puts "Running: #{command}"
-      output = `#{command}`
-      puts "Output was: #{output}"
 
-      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
-      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
-      raise "ERROR: bolt plan failed!" unless success
+      output = run_command(command, "ERROR: bolt plan failed!")
 
       return output
     end
@@ -210,13 +217,10 @@ module RefArchSetup
       command = "bolt file upload #{source} #{destination}"
       command << " --nodes #{nodes}"
       command << bolt_options_string
-      puts "Running: #{command}"
-      output = `#{command}`
-      puts "Output was: #{output}"
 
-      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
-      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
-      raise "ERROR: failed to upload file #{source} to #{destination} on #{nodes}" unless success
+      error_message = "ERROR: failed to upload file #{source} to #{destination} on #{nodes}"
+      output = run_command(command, error_message)
+      success = true unless output.nil?
 
       return success
     end
@@ -228,13 +232,8 @@ module RefArchSetup
     # @return [true,false] Based on exit status of the bolt task
     def self.install_forge_modules
       command = "bolt puppetfile install --modulepath #{FORGE_MODULE_PATH}"
-      puts "Running: #{command}"
-      output = `#{command}`
-      puts "Output was: #{output}"
-
-      success = $?.success? # rubocop:disable Style/SpecialGlobalVars
-      puts "Exit status was: #{$?.exitstatus}" # rubocop:disable Style/SpecialGlobalVars
-      raise "ERROR: bolt command failed!" unless success
+      output = run_command(command, "ERROR: bolt command failed!")
+      success = true unless output.nil?
 
       return success
     end

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -75,7 +75,9 @@ module RefArchSetup
     # @param [string] dir Directory to create
     # @param [string] nodes Hosts to make dir on
     #
-    # @return [true,false] Based on exit status of the bolt task
+    # @raise [RuntimeError] If the bolt command is not successful
+    #
+    # @return [true,false] Based on the output of the bolt task
     def self.make_dir(dir, nodes)
       cmd = "mkdir -p #{dir}"
       output = run_cmd_with_bolt(cmd, nodes)
@@ -91,6 +93,8 @@ module RefArchSetup
     #
     # @param command [string] The command to run
     # @param error_message [string] The error to raise if the command is not successful
+    #
+    # @raise [BoltCommandError] If the command is not successful
     #
     # @return [string] The output returned from the command
     def self.run_command(command, error_message = "ERROR: command failed!")
@@ -112,10 +116,10 @@ module RefArchSetup
     #
     # @author Randell Pelak
     #
-    # @param [string] cmd Command to run on nodes
-    # @param [string] nodes Host to make dir on
+    # @param [string] cmd Command to run on the specified nodes
+    # @param [string] nodes Nodes on which the command should be run
     #
-    # @return [true,false] Based on exit status of the bolt task
+    # @return [string] The output returned from the bolt command
     def self.run_cmd_with_bolt(cmd, nodes)
       command = "bolt command run '#{cmd}'"
       command << " --nodes #{nodes}"
@@ -134,7 +138,7 @@ module RefArchSetup
     # @param nodes [string] Host or space delimited hosts to run task on
     # @param modulepath [string] The modulepath to use when running bolt
     #
-    # @return [true,false] Based on exit status of the bolt task
+    # @return [string] The output returned from the bolt command
     def self.run_task_with_bolt(task, params, nodes, modulepath = RAS_MODULE_PATH)
       params_str = ""
       params_str = params_to_string(params) unless params.nil?
@@ -155,7 +159,7 @@ module RefArchSetup
     # @param nodes [string] Host or space delimited hosts to run plan on
     # @param modulepath [string] The modulepath to use when running bolt
     #
-    # @return [string] The output from the bolt run
+    # @return [string] The output returned from the bolt command
     def self.run_plan_with_bolt(plan, params, nodes, modulepath = RAS_MODULE_PATH)
       params_str = ""
       params_str = params_to_string(params) unless params.nil?
@@ -175,7 +179,7 @@ module RefArchSetup
     # @param params [hash] Task parameters to send to bolt
     # @param nodes [string] Host or space delimited hosts to run task on
     #
-    # @return [true,false] Based on exit status of the bolt task
+    # @return [string] The output returned from the bolt command
     def self.run_forge_task_with_bolt(task, params, nodes)
       install_forge_modules
       output = run_task_with_bolt(task, params, nodes, FORGE_MODULE_PATH)
@@ -190,7 +194,7 @@ module RefArchSetup
     # @param params [hash] Plan parameters to send to bolt
     # @param nodes [string] Host or space delimited hosts to run plan on
     #
-    # @return [string] The output from the bolt run
+    # @return [string] The output returned from the bolt command
     def self.run_forge_plan_with_bolt(plan, params, nodes)
       install_forge_modules
       output = run_plan_with_bolt(plan, params, nodes, FORGE_MODULE_PATH)
@@ -230,10 +234,11 @@ module RefArchSetup
     end
 
     # Install modules from the forge via Puppetfile
+    # The modules are defined in Boltdir/Puppetfile
     #
     # @author Bill Claytor
     #
-    # @return [true,false] Based on exit status of the bolt task
+    # @return [string] The output returned from the bolt command
     def self.install_forge_modules
       command = "cd #{RAS_PATH} && bolt puppetfile install --modulepath #{FORGE_MODULE_PATH}"
       output = run_command(command, "ERROR: bolt command failed!")

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -2,9 +2,6 @@
 module RefArchSetup
   # Bolt helper methods
   class BoltHelper
-    # location of modules downloaded from the Puppet Forge
-    FORGE_MODULE_PATH = File.dirname(__FILE__) + "/../../Boltdir/modules"
-
     # the user RAS will provide to the bolt --run-as option
     BOLT_RUN_AS_USER = "root".freeze
 
@@ -231,7 +228,7 @@ module RefArchSetup
     #
     # @return [true,false] Based on exit status of the bolt task
     def self.install_forge_modules
-      command = "bolt puppetfile install --modulepath #{FORGE_MODULE_PATH}"
+      command = "cd #{RAS_PATH} && bolt puppetfile install --modulepath #{FORGE_MODULE_PATH}"
       output = run_command(command, "ERROR: bolt command failed!")
       success = true unless output.nil?
 

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -77,7 +77,7 @@ module RefArchSetup
     #
     # @raise [BoltCommandError] If the bolt command is not successful or the output is nil
     #
-    # @return [string] The output returned from the command
+    # @return [true,false] Based on the output returned from the bolt command
     def self.make_dir(dir, nodes)
       error_message = "ERROR: Failed to make dir #{dir} on all nodes"
       cmd = "mkdir -p #{dir}"

--- a/lib/ref_arch_setup/cli.rb
+++ b/lib/ref_arch_setup/cli.rb
@@ -115,9 +115,9 @@ module RefArchSetup
       puts "Running bootstrap subcommand of install command"
       # none of these will be required in the future...  but are for now
       check_option("primary_master", "install")
-      check_option("pe_tarball", "install")
       install_obj = RefArchSetup::Install.new(@options["primary_master"])
-      success = install_obj.bootstrap(@options["pe_conf"], @options["pe_tarball"])
+      success = install_obj.bootstrap(@options["pe_conf"], @options["pe_tarball"],
+                                      @options["pe_version"])
       return success
     end
 

--- a/lib/ref_arch_setup/cli.rb
+++ b/lib/ref_arch_setup/cli.rb
@@ -16,7 +16,7 @@ module RefArchSetup
     # @return [void]
     def initialize(options, bolt_options)
       @options = options
-      BoltHelper.bolt_options = bolt_options
+      @bolt_options = bolt_options
     end
 
     # Check values of options to see if they are really an option
@@ -68,6 +68,8 @@ module RefArchSetup
     # @return [boolean] success of install
     def run(command, subcommand = nil)
       check_for_missing_value
+      BoltHelper.bolt_options = @bolt_options
+
       comm = command
       unless subcommand.nil?
         str = subcommand.tr("-", "_")

--- a/lib/ref_arch_setup/download_helper.rb
+++ b/lib/ref_arch_setup/download_helper.rb
@@ -348,6 +348,7 @@ module RefArchSetup
     # @param [string] hosts The host(s) from which to retrieve facts
     #
     # @raise [JSON::ParserError] If the output from the bolt plan can't be parsed
+    # @raise [BoltCommandError] If the bolt command is not successful or the output is nil
     #
     # @return [Array<Hash] The retrieved facts
     #

--- a/lib/ref_arch_setup/download_helper.rb
+++ b/lib/ref_arch_setup/download_helper.rb
@@ -67,6 +67,8 @@ module RefArchSetup
     #
     # @param [string] version The desired version of PE
     #
+    # @raise [RuntimeError] If the specified version is not valid
+    #
     # @return [string] The corresponding PE version
     #
     # @example:
@@ -111,6 +113,8 @@ module RefArchSetup
     #
     # @param [string] version The specified version of PE
     #
+    # @raise [RuntimeError] If the specified version is not found
+    #
     # @return [true, false] Whether the specified version was found
     #
     # @example:
@@ -133,6 +137,8 @@ module RefArchSetup
     # @author Bill Claytor
     #
     # @param [string] version The specified version of PE
+    #
+    # @raise [RuntimeError] If the specified version is not supported
     #
     # @return [true, false] Whether the specified version is supported
     #
@@ -208,6 +214,8 @@ module RefArchSetup
     # @param [Array] valid_response_codes The list of valid response codes
     # @param [Array] invalid_response_bodies The list of invalid response bodies
     #
+    # @raise [RuntimeError] If the response is not valid
+    #
     # @return [true,false] Based on whether the response is valid
     #
     # @example
@@ -258,6 +266,8 @@ module RefArchSetup
     # *** Specifying the host will determine and validate the platform for the host
     # *** Specifying the platform will ignore the host value and only perform the validation
     #
+    # @raise [RuntimeError] If the platform is not valid
+    #
     # @return [string] The PE platform
     #
     # @example:
@@ -281,6 +291,9 @@ module RefArchSetup
     # @author Bill Claytor
     #
     # @param [string] host The target host
+    #
+    # @raise [RuntimeError] If the facts status is 'failure'
+    # @raise [RuntimeError] If the platform can't be determined
     #
     # @return [string] The corresponding platform for the specified host
     #
@@ -334,7 +347,9 @@ module RefArchSetup
     #
     # @param [string] hosts The host(s) from which to retrieve facts
     #
-    # @return [string] The retrieved facts
+    # @raise [JSON::ParserError] If the output from the bolt plan can't be parsed
+    #
+    # @return [Array<Hash] The retrieved facts
     #
     # @example:
     #   facts = retrieve_facts("localhost")

--- a/lib/ref_arch_setup/download_helper.rb
+++ b/lib/ref_arch_setup/download_helper.rb
@@ -141,11 +141,11 @@ module RefArchSetup
     #
     def self.ensure_supported_prod_version(version)
       major_version = version.split(".")[0]
-      supported_version = MIN_PROD_VERSION.split(".")[0]
+      supported_version = @min_prod_version.split(".")[0]
 
       supported = major_version >= supported_version ? true : false
       puts "Specified version #{version} is supported by RAS" if supported
-      puts "The minimum supported version is #{MIN_PROD_VERSION}" unless supported
+      puts "The minimum supported version is #{@min_prod_version}" unless supported
 
       raise "Specified version #{version} is not supported by RAS" unless supported
 
@@ -294,7 +294,7 @@ module RefArchSetup
       facts = retrieve_facts(host)
 
       status = facts[0]["status"]
-      raise "Status for host #{host} is failure" if status == "failure"
+      raise "Facts indicate that status for host #{host} is failure" if status == "failure"
 
       os = facts[0]["result"]["os"]
       os_name = os["name"]

--- a/lib/ref_arch_setup/install.rb
+++ b/lib/ref_arch_setup/install.rb
@@ -35,6 +35,10 @@ module RefArchSetup
     # @param [string] pe_conf_path Path to pe.conf
     # @param [string] pe_tarball Path or URL for the pe tarball
     #
+    # @raise [RuntimeError] Unless either a pe_tarball or pe_version is specified
+    # @raise [RuntimeError] If a valid pe_tarball is not available
+    # @raise [RuntimeError] If a RAS working directory can not be created
+    #
     # @return [true,false] Based on exit status of the bolt task
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
@@ -90,6 +94,9 @@ module RefArchSetup
     #
     # @param [string] pe_conf_path Path to pe.conf file or dir
     #
+    # @raise [RuntimeError] If a pe.conf file is not found
+    # @raise [RuntimeError] If the file is not uploaded successfully
+    #
     # @return [string] The path to the pe.conf file on the target master
     def handle_pe_conf(pe_conf_path)
       conf_path_on_master = "#{TMP_WORK_DIR}/pe.conf"
@@ -112,6 +119,10 @@ module RefArchSetup
     # @author Randell Pelak
     #
     # @param [string] pe_conf_path Path to pe.conf file or dir
+    #
+    # @raise [RuntimeError] If a directory is specified and a pe.conf file is not found
+    # @raise [RuntimeError] If the specified file is not named pe.conf
+    # @raise [RuntimeError] If the specified file is not found
     #
     # @return [string] The path to the pe.conf file
     def handle_pe_conf_path(pe_conf_path)
@@ -148,7 +159,7 @@ module RefArchSetup
     #
     # @param [string] url URL for the PE tarball file
     #
-    # @raise [RuntimeError] Based on the validity of the url
+    # @raise [RuntimeError] If the specified URL can not be parsed
     #
     # @return [true] Based on the validity of the URL
     def parse_url(url)
@@ -167,7 +178,7 @@ module RefArchSetup
     #
     # @param [string] pe_tarball Path to PE tarball file
     #
-    # @raise [RuntimeError] Based on the validity of the extension
+    # @raise [RuntimeError] If the extension of the specified tarball is invalid
     #
     # @return [true] Based on the validity of the extension
     def validate_tarball_extension(pe_tarball)
@@ -258,6 +269,8 @@ module RefArchSetup
     #
     # @param [string] url The PE tarball URL
     #
+    # @raise [RuntimeError] If the tarball is not handled successfully
+    #
     # @return [string] The tarball path on the target master
     # rubocop:disable Metrics/MethodLength
     def handle_tarball_url(url)
@@ -315,6 +328,8 @@ module RefArchSetup
     #
     # @param [string] path The pe tarball path
     #
+    # @raise [RuntimeError] If the specified tarball is not found
+    #
     # @return [true,false] Based on exit status of the bolt task
     def handle_tarball_path_with_remote_target_master(path)
       remote_flag = "#{@target_master}:"
@@ -331,15 +346,18 @@ module RefArchSetup
       return success
     end
 
-    # Handles the specified tarball path
+    # Handles the specified tarball path based on the target_master
     #
     # @author Bill Claytor
     #
     # @param [string] path The PE tarball path
     #
-    # TODO: improve "host to install on"? ("host where PE will be installed?")
+    # @raise [RuntimeError] If the specified tarball is not found
+    # @raise [RuntimeError] If the specified tarball is not uploaded successfully
     #
     # @return [string] The tarball path on the target master
+    #
+    # TODO: improve "host to install on"? ("host where PE will be installed?")
     def handle_tarball_path(path)
       filename = File.basename(path)
       tarball_path_on_master = "#{TMP_WORK_DIR}/#{filename}"
@@ -367,6 +385,8 @@ module RefArchSetup
     # @author Bill Claytor
     #
     # @param [string] pe_tarball Path to PE tarball file
+    #
+    # @raise [RuntimeError] If the specified tarball is not handled successfully
     #
     # @return [string] The tarball path on the master after copying if successful
     def handle_pe_tarball(pe_tarball)

--- a/lib/ref_arch_setup/install.rb
+++ b/lib/ref_arch_setup/install.rb
@@ -409,7 +409,7 @@ module RefArchSetup
     #
     # @raise [BoltCommandError] If the bolt command is not successful or the output is nil
     #
-    # @return [true,false] Based on exit status of the bolt task
+    # @return [true,false] Based on the output returned from the bolt command
     def make_tmp_work_dir
       BoltHelper.make_dir(TMP_WORK_DIR, @target_master)
     end

--- a/lib/ref_arch_setup/install.rb
+++ b/lib/ref_arch_setup/install.rb
@@ -37,12 +37,13 @@ module RefArchSetup
     #
     # @return [true,false] Based on exit status of the bolt task
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def bootstrap(pe_conf_path, pe_tarball, pe_version)
-      if pe_tarball
+      if specified_option?(pe_tarball)
         puts "Proceeding with specified pe_tarball: #{pe_tarball}"
         @pe_tarball = pe_tarball
       else
-        raise "Either a pe_version or pe_tarball must be specified" unless pe_version
+        raise "Either a pe_version or pe_tarball must be specified" unless specified_option?(pe_version)
         puts "Proceeding with specified pe_version: #{pe_version}"
         @pe_tarball = RefArchSetup::DownloadHelper.build_prod_tarball_url(pe_version,
                                                                           @target_master)
@@ -58,10 +59,26 @@ module RefArchSetup
       params["pe_conf_path"] = conf_path_on_master
       params["pe_tarball_path"] = tarball_path_on_master
 
-      success = BoltHelper.run_task_with_bolt(INSTALL_PE_TASK, params, @target_master)
+      output = BoltHelper.run_task_with_bolt(INSTALL_PE_TASK, params, @target_master)
+      success = output.nil? ? false : true
       return success
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/AbcSize
+
+    # Determines whether the option is 'specified' (not nil and not empty)
+    #
+    # @author Bill Claytor
+    #
+    # @param [string] value The option value to evaluate
+    #
+    # @return [true, false] Based on the evaluation of the value
+    #
+    def specified_option?(value)
+      specified = value.nil? || value.empty? ? false : true
+      return specified
+    end
 
     # Handles user inputted pe.conf or if nil assumes it is in the CWD
     # Validates file exists (allows just a dir to be given if pe.conf is in it)
@@ -184,7 +201,14 @@ module RefArchSetup
     #
     def file_exist_on_target_master?(path)
       command = "[ -f #{path} ]"
-      exists = BoltHelper.run_cmd_with_bolt(command, @target_master)
+      exists = true
+
+      begin
+        BoltHelper.run_cmd_with_bolt(command, @target_master)
+      rescue
+        exists = false
+      end
+
       return exists
     end
 
@@ -207,7 +231,8 @@ module RefArchSetup
       params["url"] = url
       params["destination"] = TMP_WORK_DIR
 
-      success = BoltHelper.run_task_with_bolt(DOWNLOAD_PE_TARBALL_TASK, params, nodes)
+      output = BoltHelper.run_task_with_bolt(DOWNLOAD_PE_TARBALL_TASK, params, nodes)
+      success = output.nil? ? false : true
       return success
     end
 
@@ -244,12 +269,14 @@ module RefArchSetup
         success = download_pe_tarball(url, "localhost")
         raise "Failed downloading #{url} to localhost" unless success
       else
-        # if downloading to the target master fails try to download locally and then upload
         begin
+          # if downloading to the target master fails
           success = download_pe_tarball(url, @target_master)
         rescue
+          # try to download locally and then upload
           puts "Unable to download the tarball directly to #{@target_master}"
-          success = download_and_move_pe_tarball(url) unless success
+          success = download_and_move_pe_tarball(url)
+        ensure
           raise remote_error unless success
         end
 
@@ -274,7 +301,8 @@ module RefArchSetup
                   true
                 else
                   command = "cp #{tarball_path_on_target_master} #{TMP_WORK_DIR}"
-                  BoltHelper.run_cmd_with_bolt(command, @target_master)
+                  output = BoltHelper.run_cmd_with_bolt(command, @target_master)
+                  output.nil? ? false : true
                 end
 
       return success
@@ -377,7 +405,10 @@ module RefArchSetup
     def upload_pe_conf(src_pe_conf_path = "#{RAS_FIXTURES_PATH}/pe.conf",
                        dest_pe_conf_path = "#{TMP_WORK_DIR}/pe.conf",
                        target_master = @target_master)
-      return BoltHelper.upload_file(src_pe_conf_path, dest_pe_conf_path, target_master)
+      output = BoltHelper.upload_file(src_pe_conf_path, dest_pe_conf_path, target_master)
+      success = output.nil? ? false : true
+
+      return success
     end
 
     # Upload the pe tarball to the target_host
@@ -394,7 +425,10 @@ module RefArchSetup
       puts "Attempting upload from #{src_pe_tarball_path} " \
            "to #{dest_pe_tarball_path} on #{@target_master}"
 
-      return BoltHelper.upload_file(src_pe_tarball_path, dest_pe_tarball_path, @target_master)
+      output = BoltHelper.upload_file(src_pe_tarball_path, dest_pe_tarball_path, @target_master)
+      success = output.nil? ? false : true
+
+      return success
     end
   end
 end

--- a/lib/ref_arch_setup/install.rb
+++ b/lib/ref_arch_setup/install.rb
@@ -43,7 +43,8 @@ module RefArchSetup
         puts "Proceeding with specified pe_tarball: #{pe_tarball}"
         @pe_tarball = pe_tarball
       else
-        raise "Either a pe_version or pe_tarball must be specified" unless specified_option?(pe_version)
+        options_error = "Either a pe_version or pe_tarball must be specified"
+        raise options_error unless specified_option?(pe_version)
         puts "Proceeding with specified pe_version: #{pe_version}"
         @pe_tarball = RefArchSetup::DownloadHelper.build_prod_tarball_url(pe_version,
                                                                           @target_master)

--- a/modules/ref_arch_setup/tasks/install_pe.sh
+++ b/modules/ref_arch_setup/tasks/install_pe.sh
@@ -54,9 +54,9 @@ then
     fi
 fi
 
-execute_command "tar -xvf $PT_pe_tarball_path"
+execute_command "tar -xvf $PT_pe_tarball_path -C /tmp/ref_arch_setup"
 # Using -* so we don't have to know the specific version, or parse it from the install path
-execute_command "sh ./puppet-enterprise-*/puppet-enterprise-installer -c $PT_pe_conf_path"
+execute_command "sh /tmp/ref_arch_setup/puppet-enterprise-*/puppet-enterprise-installer -c $PT_pe_conf_path"
 # Must run puppet agent twice, see https://puppet.com/docs/pe/2017.3/installing/installing_pe.html#text-mode-installation-options-for-monolithic-installations
 execute_command "puppet agent -t" 2
 execute_command "puppet agent -t" 2

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -81,41 +81,135 @@ describe RefArchSetup::BoltHelper do
     end
   end
 
-  describe "run_cmd_with_bolt" do
+  describe "run_command" do
     before do
       @expected_command = "bolt command run '#{cmd}' --nodes #{nodes} #{bolt_default_string}"
     end
 
-    context "when bolt works and returns true" do
-      it "returns true and outputs informative messages" do
+    context "when the command returns true" do
+      it "outputs informative messages" do
+        expected_output = "All Good"
+        expected_status = 0
+
+        expect(RefArchSetup::BoltHelper).to receive(:`)
+          .with(@expected_command).and_return(expected_output)
+
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with(no_args)
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts)
+          .with("Exit status was: #{expected_status}")
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+
+        RefArchSetup::BoltHelper.run_command(@expected_command)
+      end
+
+      it "returns the output" do
         expected_output = "All Good"
         expected_status = 0
         expect(RefArchSetup::BoltHelper).to receive(:`)
           .with(@expected_command).and_return(expected_output)
+
         `(exit #{expected_status})`
         expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
+
+        allow(RefArchSetup::BoltHelper).to receive(:puts)
+
+        expect(RefArchSetup::BoltHelper.run_command(@expected_command)).to eq(expected_output)
+      end
+    end
+
+    context "when the command returns false" do
+      it "outputs informative messages (and raises an error)" do
+        expected_output = "No Good"
+        expected_status = 1
+
+        expect(RefArchSetup::BoltHelper).to receive(:`)
+          .with(@expected_command).and_return(expected_output)
+
+        `(exit #{expected_status})`
+        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
+
+        expect(RefArchSetup::BoltHelper).to receive(:puts).with(no_args)
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
         expect(RefArchSetup::BoltHelper).to receive(:puts)
           .with("Exit status was: #{expected_status}")
         expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+
+        expect { RefArchSetup::BoltHelper.run_command(@expected_command) }
+          .to raise_error(RuntimeError)
+      end
+
+      context "when the error is specified" do
+        it "raises the specified error" do
+          error = "ERROR: bolt command failed!"
+          expected_output = "No Good"
+          expected_status = 1
+
+          expect(RefArchSetup::BoltHelper).to receive(:`)
+            .with(@expected_command).and_return(expected_output)
+
+          `(exit #{expected_status})`
+          # rubocop:disable Style/SpecialGlobalVars
+          expect($?).to receive(:success?).and_return(false)
+          # rubocop:enable Style/SpecialGlobalVars
+
+          allow(RefArchSetup::BoltHelper).to receive(:puts)
+
+          expect { RefArchSetup::BoltHelper.run_command(@expected_command, error) }
+            .to raise_error(RuntimeError, error)
+        end
+      end
+
+      context "when the error is not specified" do
+        it "raises the default error" do
+          error = "ERROR: command failed!"
+          expected_output = "No Good"
+          expected_status = 1
+
+          expect(RefArchSetup::BoltHelper).to receive(:`)
+            .with(@expected_command).and_return(expected_output)
+
+          `(exit #{expected_status})`
+          # rubocop:disable Style/SpecialGlobalVars
+          expect($?).to receive(:success?).and_return(false)
+          # rubocop:enable Style/SpecialGlobalVars
+
+          allow(RefArchSetup::BoltHelper).to receive(:puts)
+
+          expect { RefArchSetup::BoltHelper.run_command(@expected_command) }
+            .to raise_error(RuntimeError, error)
+        end
+      end
+    end
+  end
+
+  describe "run_cmd_with_bolt" do
+    before do
+      @expected_command = "bolt command run '#{cmd}' --nodes #{nodes} #{bolt_default_string}"
+      @error_message = "ERROR: bolt command failed!"
+    end
+
+    context "when bolt succeeds and returns output" do
+      it "returns true" do
+        expected_output = "All Good"
+
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_return(expected_output)
+
         expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(true)
       end
     end
 
-    context "when bolt fails and returns false" do
-      it "outputs informative messages and raises an error" do
-        error = "ERROR: bolt command failed!"
-        expected_output = "No Good"
-        expected_status = 1
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        expect { RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes) }.to raise_error(error)
+    context "when bolt fails" do
+      it "raises the specified error" do
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_raise(RuntimeError, @error_message)
+
+        expect { RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes) }
+          .to raise_error(RuntimeError, @error_message)
       end
     end
 
@@ -127,16 +221,10 @@ describe RefArchSetup::BoltHelper do
 
       it "executes bolt command with the arguments" do
         expected_output = "All Good"
-        expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command_with_ssh).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command_with_ssh, @error_message).and_return(expected_output)
+
         expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(true)
       end
     end
@@ -148,16 +236,10 @@ describe RefArchSetup::BoltHelper do
 
       it "executes bolt command with the arguments" do
         expected_output = "All Good"
-        expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command_with_ssh).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command_with_ssh, @error_message).and_return(expected_output)
+
         expect(RefArchSetup::BoltHelper.run_cmd_with_bolt(cmd, nodes)).to eq(true)
       end
     end
@@ -167,100 +249,59 @@ describe RefArchSetup::BoltHelper do
     before do
       @expected_command = "bolt task run #{task} VAR1=1 VAR2=2 --modulepath "\
       "#{RefArchSetup::RAS_MODULE_PATH} --nodes #{nodes} #{bolt_default_string}"
+      @error_message = "ERROR: bolt task failed!"
     end
 
     context "when a modulepath is specified" do
       expected_output = "All Good"
-      expected_status = 0
       modulepath = "./my_modules"
 
       it "uses the specified value" do
-        # update @expected_command to specify the modulepath for this test only
+        # this updates @expected_command to specify the modulepath for this test only
         @expected_command = "bolt task run #{task} VAR1=1 VAR2=2 --modulepath "\
           "#{modulepath} --nodes #{nodes} #{bolt_default_string}"
 
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        allow(RefArchSetup::BoltHelper).to receive(:puts)
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_return(expected_output)
+
         expect(RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes, modulepath))
           .to eq(true)
       end
     end
 
-    context "when bolt works and returns true" do
+    context "when bolt works and returns the output" do
       expected_output = "All Good"
-      expected_status = 0
+
       it "uses the default modulepath" do
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        allow(RefArchSetup::BoltHelper).to receive(:puts)
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message)
+
         RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)
       end
 
       it "returns true" do
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        allow(RefArchSetup::BoltHelper).to receive(:puts)
-        expect(RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)).to eq(true)
-      end
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_return(expected_output)
 
-      it "outputs informative messages" do
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
-          .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)
+        expect(RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)).to eq(true)
       end
     end
 
-    context "when bolt fails and returns false" do
-      expected_output = "No Good"
-      expected_status = 1
+    context "when bolt fails" do
+      it "raises the specified error" do
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_raise(RuntimeError, @error_message)
 
-      it "raises an error" do
-        error = "ERROR: bolt task failed!"
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
-          .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
-        allow(RefArchSetup::BoltHelper).to receive(:puts)
         expect { RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes) }
-          .to raise_error(error)
-      end
-      it "outputs informative messages and raises an error" do
-        error = "ERROR: bolt task failed!"
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
-          .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect { RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes) }
-          .to raise_error(error)
+          .to raise_error(RuntimeError, @error_message)
       end
     end
 
@@ -272,18 +313,12 @@ describe RefArchSetup::BoltHelper do
 
       it "passes the argument to bolt" do
         expected_output = "All Good"
-        expected_status = 0
+
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command_with_ssh).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command_with_ssh, @error_message).and_return(expected_output)
+
         RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)
       end
     end
@@ -293,25 +328,23 @@ describe RefArchSetup::BoltHelper do
     before do
       @expected_command = "bolt plan run #{plan} VAR1=1 VAR2=2 --modulepath "\
       "#{RefArchSetup::RAS_MODULE_PATH} --nodes #{nodes} #{bolt_default_string}"
+      @error_message = "ERROR: bolt plan failed!"
     end
 
     context "when a modulepath is specified" do
       expected_output = "All Good"
-      expected_status = 0
       modulepath = "./my_modules"
 
       it "uses the specified value" do
-        # update @expected_command to specify the modulepath for this test only
+        # this updates @expected_command to specify the modulepath for this test only
         @expected_command = "bolt plan run #{plan} VAR1=1 VAR2=2 --modulepath "\
         "#{modulepath} --nodes #{nodes} #{bolt_default_string}"
 
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        allow(RefArchSetup::BoltHelper).to receive(:puts)
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_return(expected_output)
+
         expect(RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes, modulepath))
           .to eq(expected_output)
       end
@@ -319,75 +352,36 @@ describe RefArchSetup::BoltHelper do
 
     context "when bolt works and returns output" do
       expected_output = "All Good"
-      expected_status = 0
+
       it "uses the default modulepath" do
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        allow(RefArchSetup::BoltHelper).to receive(:puts)
-        RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)
-      end
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_return(expected_output)
 
-      it "outputs informative messages" do
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
-          .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
         RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)
       end
 
       it "returns the output" do
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        allow(RefArchSetup::BoltHelper).to receive(:puts)
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_return(expected_output)
+
         expect(RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes))
           .to eq(expected_output)
       end
     end
 
     context "when bolt fails" do
-      expected_output = "No Good"
-      expected_status = 1
+      it "raises the specified error" do
+        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
+          .with(params).and_return(params_str)
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_raise(RuntimeError, @error_message)
 
-      it "raises an error" do
-        error = "ERROR: bolt plan failed!"
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
-          .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
-        allow(RefArchSetup::BoltHelper).to receive(:puts)
         expect { RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes) }
-          .to raise_error(error)
-      end
-      it "outputs informative messages and raises an error" do
-        error = "ERROR: bolt plan failed!"
-        expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
-          .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect { RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes) }
-          .to raise_error(error)
+          .to raise_error(RuntimeError, @error_message)
       end
     end
 
@@ -399,18 +393,12 @@ describe RefArchSetup::BoltHelper do
 
       it "passes the argument to bolt" do
         expected_output = "All Good"
-        expected_status = 0
+
         expect(RefArchSetup::BoltHelper).to receive(:params_to_string)
           .with(params).and_return(params_str)
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command_with_ssh).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command_with_ssh, @error_message).and_return(expected_output)
+
         RefArchSetup::BoltHelper.run_plan_with_bolt(plan, params, nodes)
       end
     end
@@ -475,39 +463,27 @@ describe RefArchSetup::BoltHelper do
     before do
       @expected_command = "bolt file upload #{source} #{destination}" \
         " --nodes #{nodes} #{bolt_default_string}"
+      @error_message = "ERROR: failed to upload file #{source} to #{destination} on #{nodes}"
     end
 
     context "when bolt works and returns true" do
-      it "returns true and outputs informative messages" do
+      it "returns true" do
         expected_output = "All Good"
-        expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_return(expected_output)
+
         expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes)).to eq(true)
       end
     end
 
-    context "when bolt fails and returns false" do
-      it "outputs informative messages and raises an error" do
-        error = "ERROR: failed to upload file #{source} to #{destination} on #{nodes}"
-        expected_output = "No Good"
-        expected_status = 1
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+    context "when bolt fails" do
+      it "raises the specified error" do
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_raise(RuntimeError, @error_message)
+
         expect { RefArchSetup::BoltHelper.upload_file(source, destination, nodes) }
-          .to raise_error(error)
+          .to raise_error(RuntimeError, @error_message)
       end
     end
 
@@ -519,16 +495,10 @@ describe RefArchSetup::BoltHelper do
 
       it "passes the argument to bolt" do
         expected_output = "All Good"
-        expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)\
-          .with(@expected_command_with_ssh).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Running: #{@expected_command_with_ssh}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)\
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
+
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command_with_ssh, @error_message).and_return(expected_output)
+
         expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes)).to eq(true)
       end
     end
@@ -538,62 +508,27 @@ describe RefArchSetup::BoltHelper do
     before do
       @expected_command = "bolt puppetfile install --modulepath "\
       "#{RefArchSetup::BoltHelper::FORGE_MODULE_PATH}"
+      @error_message = "ERROR: bolt command failed!"
     end
 
-    context "when bolt works and returns true" do
-      it "outputs informative messages" do
-        expected_output = "All Good"
-        expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        RefArchSetup::BoltHelper.install_forge_modules
-      end
-
+    context "when bolt works and returns output" do
       it "returns true" do
         expected_output = "All Good"
-        expected_status = 0
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(true) # rubocop:disable Style/SpecialGlobalVars
-        allow(RefArchSetup::BoltHelper).to receive(:puts)
+
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_return(expected_output)
+
         expect(RefArchSetup::BoltHelper.install_forge_modules).to eq(true)
       end
     end
 
-    context "when bolt fails and returns false" do
-      it "outputs informative messages (and raises an error)" do
-        expected_output = "No Good"
-        expected_status = 1
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Running: #{@expected_command}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
-          .with("Exit status was: #{expected_status}")
-        expect(RefArchSetup::BoltHelper).to receive(:puts).with("Output was: #{expected_output}")
-        expect { RefArchSetup::BoltHelper.install_forge_modules }.to raise_error(RuntimeError)
-      end
+    context "when bolt fails" do
+      it "raises the specified error" do
+        expect(RefArchSetup::BoltHelper).to receive(:run_command)
+          .with(@expected_command, @error_message).and_raise(RuntimeError, @error_message)
 
-      it "raises the expected error" do
-        error = "ERROR: bolt command failed!"
-        expected_output = "No Good"
-        expected_status = 1
-        expect(RefArchSetup::BoltHelper).to receive(:`)
-          .with(@expected_command).and_return(expected_output)
-        `(exit #{expected_status})`
-        expect($?).to receive(:success?).and_return(false) # rubocop:disable Style/SpecialGlobalVars
-        allow(RefArchSetup::BoltHelper).to receive(:puts)
-        expect(RefArchSetup::BoltHelper).to receive(:puts)
         expect { RefArchSetup::BoltHelper.install_forge_modules }
-          .to raise_error(RuntimeError, error)
+          .to raise_error(RuntimeError, @error_message)
       end
     end
   end

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -413,7 +413,7 @@ describe RefArchSetup::BoltHelper do
       end
 
       it "returns the output" do
-        modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
+        modulepath = RefArchSetup::FORGE_MODULE_PATH
         expect(RefArchSetup::BoltHelper).to receive(:install_forge_modules)
         expect(RefArchSetup::BoltHelper).to receive(:run_task_with_bolt)
           .with(task, params, nodes, modulepath).and_return(true)
@@ -432,7 +432,7 @@ describe RefArchSetup::BoltHelper do
 
       it "returns the output" do
         expected_output = "All Good"
-        modulepath = RefArchSetup::BoltHelper::FORGE_MODULE_PATH
+        modulepath = RefArchSetup::FORGE_MODULE_PATH
         expect(RefArchSetup::BoltHelper).to receive(:install_forge_modules)
         expect(RefArchSetup::BoltHelper).to receive(:run_plan_with_bolt)
           .with(plan, params, nodes, modulepath).and_return(expected_output)
@@ -506,8 +506,8 @@ describe RefArchSetup::BoltHelper do
 
   describe "install_forge_modules" do
     before do
-      @expected_command = "bolt puppetfile install --modulepath "\
-      "#{RefArchSetup::BoltHelper::FORGE_MODULE_PATH}"
+      @expected_command = "cd #{RefArchSetup::RAS_PATH} && bolt puppetfile install --modulepath "\
+      "#{RefArchSetup::FORGE_MODULE_PATH}"
       @error_message = "ERROR: bolt command failed!"
     end
 

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -309,7 +309,8 @@ describe RefArchSetup::BoltHelper do
         expect(RefArchSetup::BoltHelper).to receive(:run_command)
           .with(@expected_command, @error_message).and_return(expected_output)
 
-        expect(RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes)).to eq(expected_output)
+        expect(RefArchSetup::BoltHelper.run_task_with_bolt(task, params, nodes))
+          .to eq(expected_output)
       end
     end
 
@@ -493,7 +494,8 @@ describe RefArchSetup::BoltHelper do
         expect(RefArchSetup::BoltHelper).to receive(:run_command)
           .with(@expected_command, @error_message).and_return(expected_output)
 
-        expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes)).to eq(expected_output)
+        expect(RefArchSetup::BoltHelper.upload_file(source, destination, nodes))
+          .to eq(expected_output)
       end
     end
 

--- a/spec/ref_arch_setup/cli_spec.rb
+++ b/spec/ref_arch_setup/cli_spec.rb
@@ -13,9 +13,8 @@ describe RefArchSetup::CLI do
 
   describe "Initialize" do
     it "check cli object initialization" do
-      default_bolt_options = " --run-as root"
       expect(cli.instance_variable_get("@options")).to eq(no_options)
-      expect(RefArchSetup::BoltHelper.bolt_options_string).to eq(default_bolt_options)
+      expect(cli.instance_variable_get("@bolt_options")).to eq(no_options)
     end
   end
 
@@ -54,6 +53,17 @@ describe RefArchSetup::CLI do
   end
 
   describe "run" do
+    context "when run" do
+      it "sets the bolt options" do
+        bolt_options = "--user testuser"
+        cli.instance_variable_set(:@bolt_options, bolt_options)
+
+        expect(RefArchSetup::BoltHelper).to receive(:bolt_options=).with(bolt_options)
+        expect(cli).to receive(:check_for_missing_value).and_return(true)
+        expect(cli).to receive(:install).and_return(true)
+        cli.run("install")
+      end
+    end
     context "when given only a command to run" do
       context "when the command returns true" do
         it "runs the command and returns true" do

--- a/spec/ref_arch_setup/download_helper_spec.rb
+++ b/spec/ref_arch_setup/download_helper_spec.rb
@@ -410,7 +410,7 @@ describe RefArchSetup::DownloadHelper do
 
   describe "#ensure_supported_prod_version" do
     context "when the version is supported" do
-      version = "2018.1.4"
+      version = "2076.1.1"
       message = "Specified version #{version} is supported by RAS"
 
       it "outputs a confirmation" do
@@ -426,7 +426,7 @@ describe RefArchSetup::DownloadHelper do
 
     context "when the version is not supported" do
       version = "2017.1.4"
-      message = "The minimum supported version is #{subject::MIN_PROD_VERSION}"
+      message = "The minimum supported version is #{TEST_MIN_PROD_VERSION}"
       error = "Specified version #{version} is not supported by RAS"
 
       it "outputs an explanation (and raises an error)" do

--- a/spec/ref_arch_setup/download_helper_spec.rb
+++ b/spec/ref_arch_setup/download_helper_spec.rb
@@ -130,7 +130,7 @@ describe RefArchSetup::DownloadHelper do
     subject.instance_variable_set(:@min_prod_version, TEST_MIN_PROD_VERSION)
   end
 
-  describe "#initialize" do
+  describe "#init" do
     context "when environment variables are specified" do
       versions_url = "http://this.test.net.versions"
       base_url = "http://this.test.net.base"
@@ -140,12 +140,15 @@ describe RefArchSetup::DownloadHelper do
         ENV["PE_VERSIONS_URL"] = versions_url
         ENV["BASE_PROD_URL"] = base_url
         ENV["MIN_PROD_VERSION"] = min_version
-        test_subject = RefArchSetup::DownloadHelper.new
+        RefArchSetup::DownloadHelper.init
 
-        expect(test_subject.instance_variable_get(:@pe_versions_url)).to eq(versions_url)
-        expect(test_subject.instance_variable_get(:@base_prod_url)).to eq(base_url)
-        expect(test_subject.instance_variable_get(:@min_prod_version)).to eq(min_version)
-        expect(test_subject.instance_variable_get(:@pe_platforms)).to eq(subject::PE_PLATFORMS)
+        expect(RefArchSetup::DownloadHelper.instance_variable_get(:@pe_versions_url))
+          .to eq(versions_url)
+        expect(RefArchSetup::DownloadHelper.instance_variable_get(:@base_prod_url)).to eq(base_url)
+        expect(RefArchSetup::DownloadHelper.instance_variable_get(:@min_prod_version))
+          .to eq(min_version)
+        expect(RefArchSetup::DownloadHelper.instance_variable_get(:@pe_platforms))
+          .to eq(subject::PE_PLATFORMS)
       end
     end
 
@@ -154,19 +157,26 @@ describe RefArchSetup::DownloadHelper do
         ENV["PE_VERSIONS_URL"] = nil
         ENV["BASE_PROD_URL"] = nil
         ENV["MIN_PROD_VERSION"] = nil
-        test_subject = RefArchSetup::DownloadHelper.new
 
-        expect(test_subject.instance_variable_get(:@pe_versions_url))
+        RefArchSetup::DownloadHelper.init
+
+        expect(RefArchSetup::DownloadHelper.instance_variable_get(:@pe_versions_url))
           .to eq(subject::PE_VERSIONS_URL)
-        expect(test_subject.instance_variable_get(:@base_prod_url)).to eq(subject::BASE_PROD_URL)
-        expect(test_subject.instance_variable_get(:@min_prod_version))
+        expect(RefArchSetup::DownloadHelper.instance_variable_get(:@base_prod_url))
+          .to eq(subject::BASE_PROD_URL)
+        expect(RefArchSetup::DownloadHelper.instance_variable_get(:@min_prod_version))
           .to eq(subject::MIN_PROD_VERSION)
-        expect(test_subject.instance_variable_get(:@pe_platforms)).to eq(subject::PE_PLATFORMS)
+        expect(RefArchSetup::DownloadHelper.instance_variable_get(:@pe_platforms))
+          .to eq(subject::PE_PLATFORMS)
       end
     end
   end
 
   describe "#build_prod_tarball_url" do
+    before do
+      expect(subject).to receive(:init)
+    end
+
     context "when no arguments are specified" do
       version = TEST_LATEST_VERSION
       host = "localhost"
@@ -305,7 +315,8 @@ describe RefArchSetup::DownloadHelper do
         pe_version = TEST_LATEST_VERSION
 
         expect(subject).to receive(:latest_prod_version).and_return(pe_version)
-        expect(subject).to receive(:puts).with("The latest version is: #{pe_version}")
+        expect(subject).to receive(:puts).with("The latest version is #{pe_version}")
+        expect(subject).to receive(:puts).with(no_args)
         expect(subject.handle_prod_version(version)).to eq(pe_version)
       end
     end
@@ -320,6 +331,7 @@ describe RefArchSetup::DownloadHelper do
         expect(subject).to receive(:ensure_valid_prod_version).with(version).and_return(true)
         expect(subject).to receive(:ensure_supported_prod_version).with(version).and_return(true)
         expect(subject).to receive(:puts).with(message)
+        expect(subject).to receive(:puts).with(no_args)
         expect(subject.handle_prod_version(version)).to eq(pe_version)
       end
     end
@@ -433,6 +445,23 @@ describe RefArchSetup::DownloadHelper do
 
   describe "#fetch_prod_versions" do
     context "when called" do
+      let(:test_versions_result_1) { Class.new }
+      let(:test_versions_result_2) { Class.new }
+
+      it "outputs the list of versions" do
+        test_versions_results = [test_versions_result_1, test_versions_result_2]
+        expect(subject).to receive(:parse_prod_versions_url).and_return(test_versions_results)
+        expect(subject).to receive(:puts).with("Versions:")
+
+        expect(test_versions_result_1).to receive(:text).and_return("test_versions_result_1")
+        expect(subject).to receive(:puts).with("test_versions_result_1")
+        expect(test_versions_result_2).to receive(:text).and_return("test_versions_result_2")
+        expect(subject).to receive(:puts).with("test_versions_result_2")
+
+        expect(subject).to receive(:puts).with(no_args)
+
+        subject.fetch_prod_versions
+      end
       it "returns the default result from parse_prod_versions_url" do
         allow(subject).to receive(:puts)
         expect(subject).to receive(:parse_prod_versions_url).and_return(test_versions_result)
@@ -703,10 +732,11 @@ describe RefArchSetup::DownloadHelper do
         host = "my_host"
         platform = "default"
         pe_platform = TEST_EL7_PLATFORM
+        message = "Default platform specified; determining platform for host: #{host}"
 
         it "outputs the expected message" do
           expect(subject).to receive(:puts)
-            .with("Default platform specified; determining platform for host")
+            .with(message)
 
           expect(subject).to receive(:get_host_platform)
             .with(host).and_return(pe_platform)
@@ -737,9 +767,11 @@ describe RefArchSetup::DownloadHelper do
         platform = "default"
         pe_platform = TEST_EL7_PLATFORM
         error = "Invalid PE platform: #{pe_platform}"
+        message = "Default platform specified; determining platform for host: #{host}"
+
         it "outputs the expected message (and raises an error)" do
           expect(subject).to receive(:puts)
-            .with("Default platform specified; determining platform for host")
+            .with(message)
 
           expect(subject).to receive(:get_host_platform)
             .with(host).and_return(pe_platform)

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -156,6 +156,27 @@ describe RefArchSetup::Install do
     end
   end
 
+  describe "#specified_option?" do
+    context "when the option is nil" do
+      it "returns false" do
+        value = nil
+        expect(install.specified_option?(value)).to eq(false)
+      end
+    end
+    context "when the option is empty" do
+      it "returns false" do
+        value = ""
+        expect(install.specified_option?(value)).to eq(false)
+      end
+    end
+    context "when the option is neither nil nor empty" do
+      it "returns true" do
+        value = "good"
+        expect(install.specified_option?(value)).to eq(true)
+      end
+    end
+  end
+
   describe "#handle_pe_conf_path" do
     context "When user gave a value for pe.conf that is a directory" do
       context "When a pe.conf is found in the dir" do

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -580,8 +580,8 @@ describe RefArchSetup::Install do
           context "when the subsequent download and move is not successful" do
             it "raises an error" do
               download_error = "download_pe_tarball failed"
-              remote_error = "Failed downloading #{pe_tarball_url} to localhost and moving to"\
-              " #{remote_target_master}"
+              remote_error = "Failed downloading #{pe_tarball_url} locally and moving"\
+                " to #{remote_target_master}"
 
               expect(install).to receive(:parse_url).with(pe_tarball_url).and_return(true)
               expect(install).to receive(:target_master_is_localhost?).and_return(false)

--- a/spec/ref_arch_setup/install_spec.rb
+++ b/spec/ref_arch_setup/install_spec.rb
@@ -558,9 +558,9 @@ describe RefArchSetup::Install do
 
           context "when the subsequent download and move is not successful" do
             it "raises an error" do
-              error_a = "download_pe_tarball failed"
-              error_b = "download_and_move_pe_tarball"
-              remote_error = "Failed downloading #{pe_tarball_url} to localhost and moving to #{remote_target_master}"
+              download_error = "download_pe_tarball failed"
+              remote_error = "Failed downloading #{pe_tarball_url} to localhost and moving to"\
+              " #{remote_target_master}"
 
               expect(install).to receive(:parse_url).with(pe_tarball_url).and_return(true)
               expect(install).to receive(:target_master_is_localhost?).and_return(false)
@@ -569,7 +569,7 @@ describe RefArchSetup::Install do
 
               expect(install).to receive(:download_pe_tarball)
                 .with(pe_tarball_url, remote_target_master)
-                .and_raise(RuntimeError, error_a)
+                .and_raise(RuntimeError, download_error)
 
               expect(install).to receive(:download_and_move_pe_tarball)
                 .with(pe_tarball_url)
@@ -780,7 +780,8 @@ describe RefArchSetup::Install do
 
       context "when the tarball is not handled successfully" do
         it "raises the expected error" do
-          upload_error = "Unable to upload tarball to the RAS working directory on #{remote_target_master}"
+          upload_error = "Unable to upload tarball to the RAS working directory on"\
+            " #{remote_target_master}"
 
           expect(File).to receive(:basename).with(pe_tarball).and_return(pe_tarball_filename)
           expect(install).to receive(:target_master_is_localhost?).and_return(false)
@@ -965,11 +966,11 @@ describe RefArchSetup::Install do
         src = pe_tarball
         dest = tarball_path_on_master
         message = "Attempting upload from #{src} to #{dest} on #{target_master}"
-        expected_output = "All Good"
+        expected_output = nil
 
         expect(install).to receive(:puts).with(message)
         expect(RefArchSetup::BoltHelper).to receive(:upload_file)
-          .with(src, dest, target_master).and_return(nil)
+          .with(src, dest, target_master).and_return(expected_output)
         expect(install.upload_pe_tarball(src)).to eq(false)
       end
     end


### PR DESCRIPTION
With this update RAS now accepts either a pe_tarball or pe_version. If a tarball is specified it is used (whether or not a version is specified). If a version is specified without a tarball it is used, and if neither option is specified an error is raised.

The --pe-version option accepts either "latest" or a specific PE version number. The tarball URL is then provided by `DownloadHelper.build_prod_tarball_url` which uses the [Puppet Enterprise Version History](https://puppet.com/misc/version-history) to either retrieve the latest version or verify the specified version. If a version is specified it is compared to the minimum version supported by RAS (currently 2018.1.0) to ensure compatibility. If an invalid or unsupported version is specified an error is raised with an explanation of the issue.

The `facts::retrieve` task plan is then used to determine the platform of the target_master. If the platform is in the list of supported RAS platforms it is used to build the production URL for the specified version of PE. 
