### PR TITLE
(SLV-250) Add rake task for RAS demo setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ namespace :test do
     beaker_create_host_file
   end
 
-  desc "Run acceptance test using Beaker subcommands"
+  desc "Run acceptance test suite using Beaker subcommands"
   task :acceptance do
     beaker_initialize
     Rake::Task["gem:build"].execute
@@ -46,6 +46,23 @@ namespace :test do
     Rake::Task["test:acceptance_provision"].execute
     Rake::Task["test:acceptance_exec"].execute
     Rake::Task["test:acceptance_destroy"].execute unless preserve_hosts?
+  end
+
+  desc "Run the acceptance pre-suite"
+  task :acceptance_pre_suite do
+    ENV["BEAKER_TESTS"] = "acceptance/tests/00_nothing.rb"
+    ENV["BEAKER_PRESERVE_HOSTS"] = "always"
+    Rake::Task["test:acceptance"].execute
+  end
+
+  desc "Run the demo setup from the acceptance pre-suite"
+  task :acceptance_setup_ras_demo do
+    ENV["BEAKER_PRE_SUITE"] = "acceptance/pre_suites/10_setup_ssh.rb,"\
+                              "acceptance/pre_suites/20_install_rbenv.rb,"\
+                              "acceptance/pre_suites/25_install_gems.rb,"\
+                              "acceptance/pre_suites/90_setup_ras_demo.rb"
+
+    Rake::Task["test:acceptance_pre_suite"].execute
   end
 
   desc "Run init subcommand"

--- a/acceptance/pre_suites/90_setup_ras_demo.rb
+++ b/acceptance/pre_suites/90_setup_ras_demo.rb
@@ -1,0 +1,26 @@
+test_name "install required gems on controller" do
+  step "install rake" do
+    on controller, "gem install rake"
+  end
+
+  step "install bundler" do
+    on controller, "gem install bundler"
+  end
+
+  step "add be alias for bundle exec" do
+    line = "alias be='bundle exec'"
+    command = "echo \"#{line}\" >> ~/.bashrc"
+
+    puts command
+    on controller, command
+  end
+end
+
+test_name "host info" do
+  step "output host info" do
+    puts
+    puts "controller(s): #{controller}"
+    puts "master(s): #{target_master}"
+    puts
+  end
+end

--- a/acceptance/pre_suites/90_setup_ras_demo.rb
+++ b/acceptance/pre_suites/90_setup_ras_demo.rb
@@ -1,5 +1,4 @@
 test_name "install bundler to build the RAS gem on the controller" do
-
   step "install bundler" do
     on controller, "gem install bundler"
   end

--- a/acceptance/pre_suites/90_setup_ras_demo.rb
+++ b/acceptance/pre_suites/90_setup_ras_demo.rb
@@ -1,7 +1,4 @@
-test_name "install required gems on controller" do
-  step "install rake" do
-    on controller, "gem install rake"
-  end
+test_name "install bundler to build the RAS gem on the controller" do
 
   step "install bundler" do
     on controller, "gem install bundler"
@@ -16,8 +13,8 @@ test_name "install required gems on controller" do
   end
 end
 
-test_name "host info" do
-  step "output host info" do
+test_name "output host info" do
+  step "output the host info" do
     puts
     puts "controller(s): #{controller}"
     puts "master(s): #{target_master}"


### PR DESCRIPTION
This update adds the 'acceptance_pre_suite' and 'acceptance_setup_ras_demo' rake tasks:

```
rake test:acceptance_pre_suite       # Run the acceptance pre-suite
rake test:acceptance_setup_ras_demo  # Run the demo setup from the acceptance pre-suite
```
The 'acceptance_setup_ras_demo' task sets `ENV["BEAKER_PRE_SUITE"] ` to include the following pre-suite tests:
* acceptance/pre_suites/10_setup_ssh.rb
* acceptance/pre_suites/20_install_rbenv.rb
* acceptance/pre_suites/25_install_gems.rb
* acceptance/pre_suites/90_setup_ras_demo.rb

'90_setup_ras_demo' installs rake and bundler, then outputs the host info making it easy to determine the controller. 
