### PR TITLE
(SLV-213) RAS - update README for release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,26 @@
 # How To Contribute To RefArchSetup
 
 ## Getting Started
-
 * Make sure you have a [GitHub](https://github.com) account.
 * Clone the [ref_arch_setup](https://github.com/puppetlabs/ref_arch_setup) repository on GitHub. 
     * RefArchSetup uses [gem_of](https://github.com/puppetlabs/gem_of) for some development gem dependencies and rake tasks.
     * Clone the repository and include the `gem_of` submodule:
       ```
-      git clone --recurse-submodules https://github.com/puppetlabs/ref_arch_setup.git
+      $ ~/> git clone --recurse-submodules https://github.com/puppetlabs/ref_arch_setup.git
       ```
     * If you've already cloned the repository you'll need to initialize and update the `gem_of` submodule:
       ```
       git submodule init
       git submodule update
       ```
+      
+* Navigate to the ref_arch_setup directory:
+  ```
+  $ ~/> cd ref_arch_setup
+  ```
 * Install the required gems:
   ```
-  bundle install 
+  $ ~/ref_arch_setup> bundle install 
   ```
 
 ## Filing Tickets With Jira

--- a/README.md
+++ b/README.md
@@ -108,37 +108,58 @@ Install PE on the desired primary master using the install command. For example:
 ```
     $ ref_arch_setup install --primary-master=localhost --pe-version=latest --pe-conf=/path/to/pe.conf
 ```
+### Subcommands
+RefArchSetup is currently in development and as such not all subcommands are currently available. 
+Currently only the `bootstrap` subcommand is implemented; other subcommands run in a noop mode.
 
-### --primary-master
+#### generate-pe-conf
+This subcommand has not been implemented.
+
+#### bootstrap
+This subcommand runs the bootstrap portion of the install which includes the following steps:
+* Download the PE tarball or verify a local tarball if specified
+* Extract the tarball
+* Run the PE installer
+* Run the Puppet agent until no changes are reported
+
+#### pe-infra-agent-install
+This subcommand has not been implemented.
+
+#### configure
+This subcommand has not been implemented.
+
+### Options
+
+#### --primary-master
 RefArchSetup can perform the PE installation with a local or remote primary master.
 
-#### Specifying a local primary master
+##### Specifying a local primary master
 To perform the PE installation on the same host where RefArchSetup is run, specify `--primary-master=localhost`.
 
-#### Specifying a remote primary master
+##### Specifying a remote primary master
 To perform the PE installation on a remote host, specify `--primary-master=my.remote.master`.
 If a remote host is specified it must be accessible to Bolt; see the [Bolt Options](#bolt-options) section for more information.
 
-### --pe-tarball
+#### --pe-tarball
 Specifying a PE tarball is optional, but if the option is specified it will override the `--pe-version` option.
 
-#### Specifying a tarball URL
+##### Specifying a tarball URL
 To install PE using a tarball URL, specify `--pe-tarball=https://my.host.tarball.tar.gz`.
 
-#### Specifying a tarball path
+##### Specifying a tarball path
 To install PE using a tarball on a local or remote filesystem, specify `--pe-tarball=/path/to/tarball.tar.gz`.
 
-### --pe-version
+#### --pe-version
 RefArchSetup can install a specific version of PE or the latest version. 
 See the [Puppet Enterprise Version History](https://puppet.com/misc/version-history) for a comprehensive list of PE versions.
 
-#### Install a specific version
+##### Install a specific version
 To install a specific version of PE, specify the version number: `--pe-version=2018.1.4`.
 
-#### Install the latest version 
+##### Install the latest version 
 To install the latest version, specify `--pe-version=latest`.
 
-### --pe-conf
+#### --pe-conf
 PE installation requires a valid pe.conf file. At a minimum the "console_admin_password" option must be specified.
 RefArchSetup provides a default [pe.conf](fixtures/pe.conf) file. Specify the path to the pe.conf file: `--pe-conf=/path/to/pe.conf`
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,145 @@
 # RefArchSetup
 
 ## Overview
+RefArchSetup is a Ruby gem designed to help install the various Puppet Reference Architectures. 
+It currently supports the Standard Reference Architecture.
 
-RefArchSetup is a gem designed to help install the various puppet reference architectures
+# Prerequisites
+## Ruby
+RefArchSetup uses [Puppet Bolt](https://puppet.com/products/puppet-bolt) as a gem which requires a minimum Ruby version of 2.3.
+
+## Root Access
+RefArchSetup executes commands via Bolt as the root user using the `--run-as` option to ensure a successful PE installation. 
+Access to the root user can be provided via the `--private-key` or `--sudo-password` options.
+
+## Supported Platforms
+RefArchSetup supports the following platforms:
+
+| OS                                                  | Arch   |
+|:----                                                |:----   |
+| EL (RHEL, CentOS, Scientific Linux, Oracle Linux) 6 | x86_64 |
+| EL (RHEL, CentOS, Scientific Linux, Oracle Linux) 7 | x86_64 |
+| SLES 12                                             | x86_64 |
+| Ubuntu 16.04                                        | amd64  |
+| Ubuntu 18.04                                        | amd64  |
+
+## Supported PE Versions
+RefArchSetup supports PE versions greater than 2018.1.0.
+
+## Supported Reference Architectures
+RefArchSetup currently supports the Standard Architecture.
 
 # Installation
+RefArchSetup can be installed via RubyGems or by building the gem locally. 
 
+## Install via RubyGems
+The easiest way to install RefArchSetup is via RubyGems:
+```
     $ gem install ref_arch_setup
+```
+
+## Build the gem locally
+To build the gem locally:
+* Clone the RefArchSetup and install the dependencies by following the steps in the [Getting Started](CONTRIBUTING.md) section in [CONTRIBUTING.md](CONTRIBUTING.md)
+* From your local copy of the repo, build the gem using the provided rake task:
+```
+    $ ~/ref_arch_setup> bundle exec rake gem:build
+```
+* The gem will be built to the pkg directory. Install the gem by either specifying the path to the RAS gem provided in the output from the previous step:
+```
+    $ ~/ref_arch_setup> gem install pkg/ref_arch_setup-0.0.x
+```
+or navigate to the pkg directory first, in which case specifying the version is not required:
+```
+    $ ~/ref_arch_setup> cd pkg && gem install ref_arch_setup
+```
 
 # Usage
+## Help
+RefArchSetup provides help on the command line. Run the `ref_arch_setup` command with the ` -h` option to display the available commands and options:
+```
+    $ ref_arch_setup -h
+    Usage: ref_arch_setup <command> [subcommand] [options]
+  
+    Available Commands:
+  
+      install                         - Install a bootstrapped PE on target host
+      install generate-pe-conf        - Generates a pe.conf for the install
+      install bootstrap               - Installs a bare PE on the target host
+      install pe-infra-agent-install  - Installs agents on all PE
+                                        infrastructure nodes
+      install configure               - Configures PE infrastructure nodes to
+                                        reference architecture settings
+  
+    Available Options:
+  
+      -h, --help                       Prints this help
+      -v, --version                    Show current version of ref_arch_setup
+      
+```
 
-    TBD
+Run the `ref_arch_setup install` sub-command with the ` -h` option to display the available sub-commands and options:
+```
+    $ ref_arch_setup install -h
+    Usage: ref_arch_setup install [options]
+
+    Runs the install subcommands in the following order:
+      generate-pe-conf (unless --pe-conf is provided)
+      bootstrap
+      pe-infra-agent-install (noop for "Standard" ref arch)
+      configure
+
+    Available Options:
+      Either --console-password or --pe-conf required
+        --user <username>               SSH username for bolt ssh to target host
+        --password <password>           SSH password for bolt ssh to target host
+        --private-key <path>            Path to SSH private key file for bolt
+                                        ssh to target host
+        --sudo-password <password>      Root user password for privilege escalation
+        --console-password <password>   Password for the PE console
+        --primary-master <hostname>     Hostname of primary master
+        --pe-tarball <path|URL>         Path or URL to PE tarball
+        --pe-version <version>          PE version to get tarball for
+        --pe-conf <path>                Path to pe.conf file
+```
+
+## Install
+Install PE on the desired primary master using the install command. For example:
+```
+    ref_arch_setup install --primary-master=localhost --pe-version=latest --pe-conf=/path/to/pe.conf
+```
+
+### --primary-master
+RefArchSetup can perform the PE installation with a local or remote primary master.
+
+#### Specifying a local primary master
+To perform the PE installation on the same host where RefArchSetup is run, specify `--primary-master=localhost`
+
+#### Specifying a remote primary master
+To perform the PE installation on a remote host, specify `--primary-master=my.remote.master`
+If a remote host is specified it must be accessible to Bolt; see the Bolt Options section for more information.
+
+### --pe-tarball
+Specifying a PE tarball is optional, but if the option is specified it will override the `--pe-version` option.
+
+#### Specifying a tarball URL
+To install PE using a tarball URL, specify `--pe-tarball=https://my.host.tarball.tar.gz`
+
+#### Specifying a tarball path
+To install PE using a tarball on a local or remote filesystem, specify `--pe-tarball=/path/to/tarball.tar.gz`.
+
+### --pe-version
+To install a specific version of PE, specify the version number: `--pe-version=2018.1.4`. 
+To install the latest version, specify `--pe-version=latest`
+
+### --pe-conf
+PE installation requires a valid pe.conf file. At a minimum the "console_admin_password" option must be specified.
+RefArchSetup provides a default [pe.conf](fixtures/pe.conf) file. Specify the path to the pe.conf file: `--pe-conf=/path/to/pe.conf`
 
 # License
-
 See [LICENSE](LICENSE) file.
 
 # Support & Issues
-
 Please log tickets and issues in the 
 [SLV project](https://tickets.puppetlabs.com/projects/SLV/).
 
@@ -25,6 +147,5 @@ For additional information on filing tickets, please check out our
 [CONTRIBUTOR doc](CONTRIBUTING.md).
 
 # Maintainers
-
 For information on project maintainers, please check out our
 [MAINTAINERS doc](MAINTAINERS.md).

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Run the `ref_arch_setup install` sub-command with the ` -h` option to display th
 ## Install
 Install PE on the desired primary master using the install command. For example:
 ```
-    ref_arch_setup install --primary-master=localhost --pe-version=latest --pe-conf=/path/to/pe.conf
+    $ ref_arch_setup install --primary-master=localhost --pe-version=latest --pe-conf=/path/to/pe.conf
 ```
 
 ### --primary-master

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To perform the PE installation on the same host where RefArchSetup is run, speci
 
 #### Specifying a remote primary master
 To perform the PE installation on a remote host, specify `--primary-master=my.remote.master`
-If a remote host is specified it must be accessible to Bolt; see the Bolt Options section for more information.
+If a remote host is specified it must be accessible to Bolt; see the [Bolt Options](#bolt-options) section for more information.
 
 ### --pe-tarball
 Specifying a PE tarball is optional, but if the option is specified it will override the `--pe-version` option.
@@ -135,6 +135,18 @@ To install the latest version, specify `--pe-version=latest`
 ### --pe-conf
 PE installation requires a valid pe.conf file. At a minimum the "console_admin_password" option must be specified.
 RefArchSetup provides a default [pe.conf](fixtures/pe.conf) file. Specify the path to the pe.conf file: `--pe-conf=/path/to/pe.conf`
+
+## Bolt Options
+
+### --user
+To execute Bolt commands via ssh using a different user than the user running RefArchSetup, specify `--user=my.ssh.user`. 
+Bolt can authenticate using a password or a private key file.
+
+### --password
+To authenticate using a password, specify `--password=mypassword`
+
+### --private-key
+To authenticate using a private key, specify `--private-key=/path/to/my_key.rsa`
 
 # License
 See [LICENSE](LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It currently supports the Standard Reference Architecture.
 RefArchSetup uses [Puppet Bolt](https://puppet.com/products/puppet-bolt) as a gem which requires a minimum Ruby version of 2.3.
 
 ## Root Access
-RefArchSetup executes commands via Bolt as the root user using the `--run-as` option to ensure a successful PE installation. 
-Access to the root user can be provided via the `--private-key` or `--sudo-password` options.
+RefArchSetup executes Bolt commands as the root user using the `--run-as root` option to ensure a successful PE installation. 
+See the [Bolt Options](#bolt-options) section for more information.
 
 ## Supported Platforms
 RefArchSetup supports the following platforms:
@@ -144,15 +144,19 @@ RefArchSetup provides a default [pe.conf](fixtures/pe.conf) file. Specify the pa
 
 ## Bolt Options
 
+### --sudo-password
+RefArchSetup executes Bolt commands as the root user using the `--run-as` option. 
+If RefArchSetup is run as a user other than root the sudo password must be specified: `--sudo-password=mysudopassword`
+
 ### --user
-To execute Bolt commands via ssh using a different user than the user running RefArchSetup, specify `--user=my.ssh.user`. 
+To execute Bolt commands via ssh with a user other than the user running RefArchSetup, specify `--user=my.ssh.user`. 
 Bolt can authenticate using a password or a private key file.
 
 ### --password
-To authenticate using a password, specify `--password=mypassword`
+To authenticate using a password, specify `--password=mypassword`.
 
 ### --private-key
-To authenticate using a private key, specify `--private-key=/path/to/my_key.rsa`
+To authenticate using a private key, specify `--private-key=/path/to/my_key.rsa`.
 
 # License
 See [LICENSE](LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ RefArchSetup supports PE versions greater than 2018.1.0.
 RefArchSetup currently supports the Standard Architecture.
 
 # Installation
-RefArchSetup can be installed via RubyGems or by building the gem locally. 
+RefArchSetup can be installed via [RubyGems](https://rubygems.org/gems/ref_arch_setup) or by building the gem locally. 
 
 ## Install via RubyGems
-The easiest way to install RefArchSetup is via RubyGems:
+The easiest way to install RefArchSetup is via [RubyGems](https://rubygems.org/gems/ref_arch_setup):
 ```
     $ gem install ref_arch_setup
 ```
@@ -129,8 +129,14 @@ To install PE using a tarball URL, specify `--pe-tarball=https://my.host.tarball
 To install PE using a tarball on a local or remote filesystem, specify `--pe-tarball=/path/to/tarball.tar.gz`.
 
 ### --pe-version
-To install a specific version of PE, specify the version number: `--pe-version=2018.1.4`. 
-To install the latest version, specify `--pe-version=latest`
+RefArchSetup can install a specific version of PE or the latest version. 
+See the [Puppet Enterprise Version History](https://puppet.com/misc/version-history) for a comprehensive list of PE versions.
+
+#### Install a specific version
+To install a specific version of PE, specify the version number: `--pe-version=2018.1.4`.
+
+#### Install the latest version 
+To install the latest version, specify `--pe-version=latest`.
 
 ### --pe-conf
 PE installation requires a valid pe.conf file. At a minimum the "console_admin_password" option must be specified.

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ The easiest way to install RefArchSetup is via [RubyGems](https://rubygems.org/g
 
 ## Build the gem locally
 To build the gem locally:
-* Clone the RefArchSetup and install the dependencies by following the steps in the [Getting Started](CONTRIBUTING.md) section in [CONTRIBUTING.md](CONTRIBUTING.md)
-* From your local copy of the repo, build the gem using the provided rake task:
+* Clone the RefArchSetup repository and install the dependencies by following the steps in the [Getting Started](CONTRIBUTING.md) section in [CONTRIBUTING.md](CONTRIBUTING.md).
+* From your local copy of the repository, build the gem using the provided rake task:
 ```
     $ ~/ref_arch_setup> bundle exec rake gem:build
 ```
-* The gem will be built to the pkg directory. Install the gem by either specifying the path to the RAS gem provided in the output from the previous step:
+* The gem will be built to the pkg directory; install the gem by either specifying the path to the RAS gem provided in the output from the previous step:
 ```
     $ ~/ref_arch_setup> gem install pkg/ref_arch_setup-0.0.x
 ```
@@ -113,17 +113,17 @@ Install PE on the desired primary master using the install command. For example:
 RefArchSetup can perform the PE installation with a local or remote primary master.
 
 #### Specifying a local primary master
-To perform the PE installation on the same host where RefArchSetup is run, specify `--primary-master=localhost`
+To perform the PE installation on the same host where RefArchSetup is run, specify `--primary-master=localhost`.
 
 #### Specifying a remote primary master
-To perform the PE installation on a remote host, specify `--primary-master=my.remote.master`
+To perform the PE installation on a remote host, specify `--primary-master=my.remote.master`.
 If a remote host is specified it must be accessible to Bolt; see the [Bolt Options](#bolt-options) section for more information.
 
 ### --pe-tarball
 Specifying a PE tarball is optional, but if the option is specified it will override the `--pe-version` option.
 
 #### Specifying a tarball URL
-To install PE using a tarball URL, specify `--pe-tarball=https://my.host.tarball.tar.gz`
+To install PE using a tarball URL, specify `--pe-tarball=https://my.host.tarball.tar.gz`.
 
 #### Specifying a tarball path
 To install PE using a tarball on a local or remote filesystem, specify `--pe-tarball=/path/to/tarball.tar.gz`.

--- a/lib/ref_arch_setup/download_helper.rb
+++ b/lib/ref_arch_setup/download_helper.rb
@@ -17,7 +17,11 @@ module RefArchSetup
     MIN_PROD_VERSION = "2018.1.0".freeze
 
     # the supported platforms for PE installation using RAS
-    PE_PLATFORMS = ["el-6-x86_64", "el-7-x86_64", "sles-12-x86_64", "ubuntu-16.04-amd64"].freeze
+    PE_PLATFORMS = %w[el-6-x86_64
+                      el-7-x86_64
+                      sles-12-x86_64
+                      ubuntu-16.04-amd64
+                      ubuntu-18.04-amd64].freeze
 
     # Initializes the instance variables to the defaults
     # or values specified by environment variables

--- a/ref_arch_setup.gemspec
+++ b/ref_arch_setup.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = ["ref_arch_setup"]
   spec.require_paths = ["lib"]
 
+  # Bolt requires Ruby ~> 2.3
+  spec.required_ruby_version = '>= 2.3.0'
+
   # Run time dependencies
   spec.add_runtime_dependency "bolt", "~> 0.22.0"
   spec.add_runtime_dependency "oga", "~> 2.15"

--- a/ref_arch_setup.gemspec
+++ b/ref_arch_setup.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Bolt requires Ruby ~> 2.3
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = ">= 2.3.0"
 
   # Run time dependencies
   spec.add_runtime_dependency "bolt", "~> 0.22.0"


### PR DESCRIPTION
CONTRIBUTING: updated command line examples to indicate directory
README: updated to reflect current functionality
----
Update: Added SLV-144 'RAS: determine and update minimum ruby version'. Updated the gemspec to specify Ruby >= 2.3.0 as Bolt requires Ruby ~> 2.3.
