### PR TITLE
(SLV-277) SPIKE - Investigate running RAS in a container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.*
+coverage
+doc
+junit
+log
+pkg
+vendor

--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+SSH_SOURCE=~/.ssh
+RAS_TARGET=prod
+CONTROLLER_TARGET=controller
+MASTER_TARGET=master

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -164,5 +164,5 @@ The 'bin/docker/ref_arch_setup' script starts the container with ~/.ssh mounted,
 
 * Run ref_arch_setup to install the latest version of PE
 ```
-[root@<vmpooler_controller> ref_arch_setup]# ./bin/docker/ref_arch_setup install --pe-conf=pe.conf --pe-version=latest --primary-master=onillx330ku80pv.delivery.puppetlabs.net --user=root
+[root@<vmpooler_controller> ref_arch_setup]# ./bin/docker/ref_arch_setup install --pe-conf=pe.conf --pe-version=latest --primary-master=<vmpooler_master> --user=root
 ```

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,147 @@
+# Running RAS in Docker
+This experimental update allows running RAS in a Docker container. 
+It uses docker-compose to set up an acceptance testing environment with 'controller' and 'master' containers.
+
+## Dockerfile
+The current configuration uses a Dockerfile with multi-stage builds:
+
+* FROM ruby:alpine as base
+* FROM base as sshd
+* FROM base as build
+* FROM base as prod
+
+There are also stages for the docker acceptance tests:
+* FROM prod as controller
+* FROM sshd as master
+
+## docker-compose.yml
+The docker-compose.yml specifies a general 'ras' service as well as 'controller' and 'master' services for acceptance testing.
+
+## .env
+The .env file specifies default values for the parameters used in docker-compose.yml
+
+## bin/docker
+The scripts in bin/docker use the services specified in docker-compose.yml with the targets specified in the Dockerfile.
+
+### attach
+These scripts run and attach to the specified container, building the image if necessary.
+* attach
+* attach_build
+* attach_master
+* attach_controller
+
+The `attach` script attaches to the specified target:
+```
+./bin/docker/attach prod
+```
+
+The other scripts attach to their respective default targets.
+
+### build
+Build the specified target using cached images or rebuild it from scratch
+* build	
+* rebuild
+```
+./bin/docker/rebuild prod
+```
+
+### ssh
+* setup_ssh - Create the id_rsa, id_rsa.pub, and authorized_keys files (unless they already exist)
+* ssh_entrypoint.sh - The entrypoint for the 'master' container in the acceptance test environment
+	
+### run
+* ref_arch_setup - Run the 'ref_arch_setup' command in the ras container with the prod target
+```
+./bin/docker/ref_arch_setup install -h
+```
+
+
+## Acceptance test environment 
+
+### Set up Docker on vmpooler(optional)
+* To ensure a clean environment, run the rake task to provision a vmpooler controller and master with Docker installed on the controller:
+
+```
+ras.user:~/RubymineProjects/ref_arch_setup> be rake test:acceptance_setup_ras_docker_demo
+```
+
+* SSH to the vmpooler controller
+
+
+### Set up the RAS puppercon environment
+* Clone the repo with the puppercon branch and cd into ref_arch_setup:
+
+```
+[root@<vmpooler_controller> ~]# git clone -b puppercon --recurse-submodules https://github.com/puppetlabs/ref_arch_setup.git && cd ref_arch_setup
+```
+
+* Create ssh keys
+The setup_ssh script will create the id_rsa, id_rsa.pub, and authorized_keys files (unless they already exist)
+
+```
+[root@<vmpooler_controller> ref_arch_setup]# ./bin/docker/setup_ssh
+```
+
+### Controller container
+* Build and attach to the 'controller'
+```
+[root@<vmpooler_controller> ref_arch_setup]# ./bin/docker/attach_controller
+```
+
+* When the build completes you should have a bash prompt for the controller container
+
+### Master container
+
+* Launch a new terminal and SSH to the vmpooler controller
+
+* Navigate to ref_arch_setup
+```
+[root@<vmpooler_controller> ~]# cd ref_arch_setup
+```
+
+* Build and attach to the 'master'
+```
+[root@<vmpooler_controller> ref_arch_setup]# ./bin/docker/attach_master
+```
+
+* When the build completes you should see sshd listening on port 22 on the master container
+
+### Back in the controller container
+
+* Test bolt
+```
+bash-4.4# bolt command run 'echo HELLO RAS!!!' --nodes=master --user=root --no-host-key-check
+```
+
+
+* Run ref_arch_setup with the docker master
+```
+bash-4.4# ref_arch_setup install --pe-conf=pe.conf --pe-tarball=puppet-enterprise-2019.0-rc1-7-gd82666f-el-7-x86_64.tar --primary-master=master --user=root
+```
+
+### Controller container with vmpooler master
+The controller container can also use the vmpooler master.
+
+* Add the public key to the authorized_keys file
+```
+[root@<vmpooler_controller> ref_arch_setup]# ssh-copy-id -i ./fixtures/.ssh/id_rsa.pub root@<vmpooler_master>
+```
+
+* Run ref_arch_setup with the vmpooler master
+```
+bash-4.4# ref_arch_setup install --pe-conf=pe.conf --pe-tarball=puppet-enterprise-2019.0-rc1-7-gd82666f-el-7-x86_64.tar --primary-master=onillx330ku80pv.delivery.puppetlabs.net --user=root
+```
+
+### Teardown
+* Exit the controller container
+```
+bash-4.4# exit
+```
+
+* Stop the 'master' container
+```
+[root@<vmpooler_controller> ref_arch_setup]# docker stop master
+```
+
+
+			

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -2,7 +2,8 @@
 This experimental update allows running RAS in a Docker container. 
 It uses docker-compose to set up an acceptance testing environment with 'controller' and 'master' containers.
 
-## Dockerfile
+## Configuration
+### Dockerfile
 The current configuration uses a Dockerfile with multi-stage builds:
 
 * FROM ruby:alpine as base
@@ -14,16 +15,16 @@ There are also stages for the docker acceptance tests:
 * FROM prod as controller
 * FROM sshd as master
 
-## docker-compose.yml
-The docker-compose.yml specifies a general 'ras' service as well as 'controller' and 'master' services for acceptance testing.
+### docker-compose.yml
+The docker-compose.yml file includes a general 'ras' service as well as 'controller' and 'master' services for acceptance testing.
 
-## .env
+### .env
 The .env file specifies default values for the parameters used in docker-compose.yml
 
-## bin/docker
+### bin/docker
 The scripts in bin/docker use the services specified in docker-compose.yml with the targets specified in the Dockerfile.
 
-### attach
+#### attach
 These scripts run and attach to the specified container, building the image if necessary.
 * attach
 * attach_build
@@ -37,7 +38,7 @@ The `attach` script attaches to the specified target:
 
 The other scripts attach to their respective default targets.
 
-### build
+#### build
 Build the specified target using cached images or rebuild it from scratch
 * build	
 * rebuild
@@ -45,18 +46,41 @@ Build the specified target using cached images or rebuild it from scratch
 ./bin/docker/rebuild prod
 ```
 
-### ssh
+#### ssh
 * setup_ssh - Create the id_rsa, id_rsa.pub, and authorized_keys files (unless they already exist)
 * ssh_entrypoint.sh - The entrypoint for the 'master' container in the acceptance test environment
 	
-### run
+#### run
 * ref_arch_setup - Run the 'ref_arch_setup' command in the ras container with the prod target
 ```
 ./bin/docker/ref_arch_setup install -h
 ```
+## Usage
+The current configuration supports several usage models. 
 
+### Run RAS in a single container
+The docker-compose.yml file includes a general 'ras' service which can be used with any of the build targets.
+
+#### Run single commands
+To run single commands use `./bin/docker/ref_arch_setup <command> <options>`. 
+This script will pass the command and options to ref_arch_setup in the container.
+
+#### Attach to the container
+To attach to the container use `./bin/docker/attach prod`.
+
+### Run RAS with 'controller' and 'master' containers
+The docker-compose.yml file also includes 'controller' and 'master' services for acceptance testing.
+See the [Acceptance test environment](#acceptance-test-environment) section for more information.
+
+### Run RAS in a container with a remote master
+The 'ras' and 'controller' services can both be used with a remote master as long as ssh is configured.
+The primary difference between these services is the default ssh folder mounted in the container.
+The 'ras' service uses '~/.ssh' by default since it mainly intended to be used with a remote master.
+The 'controller' service uses './fixtures/.ssh' since it is mainly intended to be used with the 'master' container for acceptance testing.
+See [Using the vmpooler master](#using-the-vmpooler-master) for more information.
 
 ## Acceptance test environment 
+The current configuration provides the ability to run RAS in a 'controller' container with a 'master' container serving as the primary master.
 
 ### Set up Docker on vmpooler
 * To ensure a clean environment, run the rake task to provision a vmpooler controller and master with Docker installed on the controller:
@@ -68,11 +92,11 @@ ras.user:~/RubymineProjects/ref_arch_setup> be rake test:acceptance_setup_ras_do
 * SSH to the vmpooler controller
 
 
-### Set up the RAS puppercon environment
-* Clone the repo with the puppercon branch and cd into ref_arch_setup:
+### Set up the RAS Docker environment
+* Clone the repo and cd into ref_arch_setup:
 
 ```
-[root@<vmpooler_controller> ~]# git clone -b puppercon --recurse-submodules https://github.com/puppetlabs/ref_arch_setup.git && cd ref_arch_setup
+[root@<vmpooler_controller> ~]# git clone --recurse-submodules https://github.com/puppetlabs/ref_arch_setup.git && cd ref_arch_setup
 ```
 
 * Create ssh keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /ref_arch_setup
 
 # Copy requirements to install
 COPY Gemfile /ref_arch_setup
-COPY Gemfile.lock /ref_arch_setup
 COPY ref_arch_setup.gemspec /ref_arch_setup
 
 COPY lib/ref_arch_setup/version.rb /ref_arch_setup/lib/ref_arch_setup/version.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY . /ref_arch_setup
 RUN bundle exec rake gem:build
 RUN cd pkg && gem install ref_arch_setup && cd ..
 
-### Install ###
+### Production ###
 FROM base as prod
 
 COPY fixtures/pe.conf /ref_arch_setup/pe.conf
@@ -40,3 +40,7 @@ COPY --from=build /ref_arch_setup/pkg /ref_arch_setup/pkg
 
 RUN cd pkg && gem install ref_arch_setup --no-rdoc --no-ri && cd ..
 RUN rm -rf /ref_arch_setup/pkg
+
+### Acceptance ###
+FROM prod as acceptance
+COPY fixtures/*.tar /ref_arch_setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM ruby:alpine
+
+ENV BUILD_PACKAGES build-base
+
+# Update and install all of the required packages.
+# At the end, remove the apk cache
+RUN apk update && \
+    apk upgrade && \
+    apk add $BUILD_PACKAGES && \
+    rm -rf /var/cache/apk/*
+
+# Create the ras dir (future workdir) and copy the pe.conf
+RUN mkdir /ras
+COPY fixtures/pe.conf /ras/pe.conf
+
+# Create ref_arch_setup dir and set as the workdir for the build
+RUN mkdir /ref_arch_setup
+WORKDIR /ref_arch_setup
+
+# Copy requirements to install
+COPY Gemfile /ref_arch_setup
+COPY Gemfile.lock /ref_arch_setup
+COPY ref_arch_setup.gemspec /ref_arch_setup
+
+COPY lib/ref_arch_setup/version.rb /ref_arch_setup/lib/ref_arch_setup/version.rb
+
+ADD ./gem_of /ref_arch_setup/gem_of
+
+RUN bundle install
+
+# Copy ref_arch_setup
+COPY . /ref_arch_setup
+
+# Build and install the gem
+RUN bundle exec rake gem:build
+RUN cd pkg && gem install ref_arch_setup && cd ..
+
+# Switch the workdir and remove ref_arch_setup
+WORKDIR /ras
+RUN rm -rf /ref_arch_setup
+

--- a/Rakefile
+++ b/Rakefile
@@ -65,6 +65,14 @@ namespace :test do
     Rake::Task["test:acceptance_pre_suite"].execute
   end
 
+  desc "Run the docker demo setup from the acceptance pre-suite"
+  task :acceptance_setup_ras_docker_demo do
+    ENV["BEAKER_PRE_SUITE"] = "acceptance/pre_suites/10_setup_ssh.rb,"\
+                              "acceptance/pre_suites/91_setup_docker.rb"
+
+    Rake::Task["test:acceptance_pre_suite"].execute
+  end
+
   desc "Run init subcommand"
   rototiller_task :acceptance_init do |task|
     beaker_init(task)
@@ -83,6 +91,16 @@ namespace :test do
   desc "Run destroy subcommand"
   rototiller_task :acceptance_destroy do |task|
     beaker_destroy(task)
+  end
+
+  desc "Run docker acceptance test suite using Beaker subcommands"
+  task :acceptance_docker do
+    beaker_initialize
+    Rake::Task["gem:build"].execute
+    Rake::Task["test:acceptance_init"].execute
+    Rake::Task["test:acceptance_provision"].execute
+    Rake::Task["test:acceptance_exec"].execute
+    Rake::Task["test:acceptance_destroy"].execute unless preserve_hosts?
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/Rakefile
+++ b/Rakefile
@@ -92,16 +92,6 @@ namespace :test do
   rototiller_task :acceptance_destroy do |task|
     beaker_destroy(task)
   end
-
-  desc "Run docker acceptance test suite using Beaker subcommands"
-  task :acceptance_docker do
-    beaker_initialize
-    Rake::Task["gem:build"].execute
-    Rake::Task["test:acceptance_init"].execute
-    Rake::Task["test:acceptance_provision"].execute
-    Rake::Task["test:acceptance_exec"].execute
-    Rake::Task["test:acceptance_destroy"].execute unless preserve_hosts?
-  end
 end
 # rubocop:enable Metrics/BlockLength
 

--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,8 @@ namespace :test do
     ENV["BEAKER_PRE_SUITE"] = "acceptance/pre_suites/10_setup_ssh.rb,"\
                               "acceptance/pre_suites/20_install_rbenv.rb,"\
                               "acceptance/pre_suites/25_install_gems.rb,"\
-                              "acceptance/pre_suites/90_setup_ras_demo.rb"
+                              "acceptance/pre_suites/90_setup_ras_demo.rb,"\
+                              "acceptance/pre_suites/99_output_host_info.rb"
 
     Rake::Task["test:acceptance_pre_suite"].execute
   end
@@ -68,7 +69,8 @@ namespace :test do
   desc "Run the docker demo setup from the acceptance pre-suite"
   task :acceptance_setup_ras_docker_demo do
     ENV["BEAKER_PRE_SUITE"] = "acceptance/pre_suites/10_setup_ssh.rb,"\
-                              "acceptance/pre_suites/91_setup_docker.rb"
+                              "acceptance/pre_suites/91_setup_docker.rb,"\
+                              "acceptance/pre_suites/99_output_host_info.rb"
 
     Rake::Task["test:acceptance_pre_suite"].execute
   end

--- a/acceptance/config/options.rb
+++ b/acceptance/config/options.rb
@@ -19,7 +19,8 @@
     "acceptance/pre_suites/20_install_rbenv.rb",
     "acceptance/pre_suites/25_install_gems.rb",
     "acceptance/pre_suites/30_setup_ras.rb",
-    "acceptance/pre_suites/40_download_pe_tarball.rb"
+    "acceptance/pre_suites/40_download_pe_tarball.rb",
+    "acceptance/pre_suites/99_output_host_info.rb"
   ],
   :tests => [
     "acceptance/tests/110_install_test_remote_master_tarball_url.rb",

--- a/acceptance/pre_suites/00_nothing.rb
+++ b/acceptance/pre_suites/00_nothing.rb
@@ -1,0 +1,4 @@
+test_name "nothing" do
+  step "nothing to do" do
+  end
+end

--- a/acceptance/pre_suites/90_setup_ras_demo.rb
+++ b/acceptance/pre_suites/90_setup_ras_demo.rb
@@ -11,12 +11,3 @@ test_name "install bundler to build the RAS gem on the controller" do
     on controller, command
   end
 end
-
-test_name "output host info" do
-  step "output the host info" do
-    puts
-    puts "controller(s): #{controller}"
-    puts "master(s): #{target_master}"
-    puts
-  end
-end

--- a/acceptance/pre_suites/91_setup_docker.rb
+++ b/acceptance/pre_suites/91_setup_docker.rb
@@ -23,14 +23,22 @@ test_name "install docker on the controller" do
     puts command
     on controller, command
   end
+end
 
+test_name "install docker-compose on the controller" do
   step "install docker-compose" do
-    url = "https://github.com/docker/compose/releases/download/1.23.1/docker-compose-$(uname -s)-$(uname -m)"
-    command = "curl -L #{url}  -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose"
+    docker_compose = "docker-compose-$(uname -s)-$(uname -m)"
+    url = "https://github.com/docker/compose/releases/download/1.23.1/#{docker_compose}"
+    command = "curl -L #{url}  -o /usr/local/bin/docker-compose"
     puts command
     on controller, command
   end
 
+  step "update docker-compose permissions" do
+    command = "chmod +x /usr/local/bin/docker-compose"
+    puts command
+    on controller, command
+  end
 end
 
 test_name "output host info" do

--- a/acceptance/pre_suites/91_setup_docker.rb
+++ b/acceptance/pre_suites/91_setup_docker.rb
@@ -40,12 +40,3 @@ test_name "install docker-compose on the controller" do
     on controller, command
   end
 end
-
-test_name "output host info" do
-  step "output the host info" do
-    puts
-    puts "controller(s): #{controller}"
-    puts "master(s): #{target_master}"
-    puts
-  end
-end

--- a/acceptance/pre_suites/91_setup_docker.rb
+++ b/acceptance/pre_suites/91_setup_docker.rb
@@ -1,0 +1,43 @@
+test_name "install docker on the controller" do
+  step "install dependencies" do
+    command = "yum install -y yum-utils device-mapper-persistent-data lvm2 git"
+    puts command
+    on controller, command
+  end
+
+  step "add docker repo" do
+    url = "https://download.docker.com/linux/centos/docker-ce.repo"
+    command = "yum-config-manager --add-repo #{url}"
+    puts command
+    on controller, command
+  end
+
+  step "install docker" do
+    command = "yum install -y docker-ce"
+    puts command
+    on controller, command
+  end
+
+  step "start docker" do
+    command = "systemctl start docker"
+    puts command
+    on controller, command
+  end
+
+  step "install docker-compose" do
+    url = "https://github.com/docker/compose/releases/download/1.23.1/docker-compose-$(uname -s)-$(uname -m)"
+    command = "curl -L #{url}  -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose"
+    puts command
+    on controller, command
+  end
+
+end
+
+test_name "output host info" do
+  step "output the host info" do
+    puts
+    puts "controller(s): #{controller}"
+    puts "master(s): #{target_master}"
+    puts
+  end
+end

--- a/acceptance/pre_suites/99_output_host_info.rb
+++ b/acceptance/pre_suites/99_output_host_info.rb
@@ -1,0 +1,8 @@
+test_name "output host info" do
+  step "output the host info" do
+    puts
+    puts "controller(s): #{controller}"
+    puts "master(s): #{target_master}"
+    puts
+  end
+end

--- a/acceptance/tests/00_nothing.rb
+++ b/acceptance/tests/00_nothing.rb
@@ -1,0 +1,4 @@
+test_name "nothing" do
+  step "nothing to do" do
+  end
+end

--- a/bin/docker/acceptance
+++ b/bin/docker/acceptance
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+export RAS_TARGET=acceptance
+
+cd "$(dirname "$0")/.." || exit 1
+
+docker-compose run  --rm -e RAS_TARGET ras "$@"

--- a/bin/docker/acceptance
+++ b/bin/docker/acceptance
@@ -1,7 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET=acceptance
-
-cd "$(dirname "$0")/.." || exit 1
-
-docker-compose run  --rm -e RAS_TARGET ras "$@"
+docker-compose run  --rm -e RAS_TARGET controller "$@"

--- a/bin/docker/acceptance
+++ b/bin/docker/acceptance
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET=acceptance
-docker-compose run  --rm -e RAS_TARGET controller "$@"
+docker-compose run --rm --name controller -e RAS_TARGET controller "$@"

--- a/bin/docker/attach
+++ b/bin/docker/attach
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET="$@"
-docker-compose run --rm -e RAS_TARGET controller /bin/bash
+docker-compose run --rm -e RAS_TARGET "$@" /bin/bash

--- a/bin/docker/attach
+++ b/bin/docker/attach
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET="$@"
-docker-compose run  --rm -e RAS_TARGET controller /bin/bash
+docker-compose run --rm -e RAS_TARGET controller /bin/bash

--- a/bin/docker/attach
+++ b/bin/docker/attach
@@ -1,7 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET="$@"
-
-cd "$(dirname "$0")/.." || exit 1
-
-docker-compose run  --rm -e RAS_TARGET ras /bin/bash
+docker-compose run  --rm -e RAS_TARGET controller /bin/bash

--- a/bin/docker/attach
+++ b/bin/docker/attach
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+export RAS_TARGET="$@"
+
+cd "$(dirname "$0")/.." || exit 1
+
+docker-compose run  --rm -e RAS_TARGET ras /bin/bash

--- a/bin/docker/attach_acceptance
+++ b/bin/docker/attach_acceptance
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET=acceptance
-docker-compose run  --rm controller "/bin/bash"
+docker-compose run --rm --name controller -e RAS_TARGET controller "/bin/bash"

--- a/bin/docker/attach_acceptance
+++ b/bin/docker/attach_acceptance
@@ -1,7 +1,4 @@
 #! /bin/sh
 
-export RAS_TARGET=prod
-
-cd "$(dirname "$0")/.." || exit 1
-
-docker-compose run  --rm ras "/bin/bash"
+export RAS_TARGET=acceptance
+docker-compose run  --rm controller "/bin/bash"

--- a/bin/docker/attach_acceptance
+++ b/bin/docker/attach_acceptance
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+export RAS_TARGET=prod
+
+cd "$(dirname "$0")/.." || exit 1
+
+docker-compose run  --rm ras "/bin/bash"

--- a/bin/docker/attach_build
+++ b/bin/docker/attach_build
@@ -1,7 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET=build
-
-cd "$(dirname "$0")/.." || exit 1
-
-docker-compose run  --rm -e RAS_TARGET ras "/bin/bash"
+docker-compose run  --rm -e RAS_TARGET controller "/bin/bash"

--- a/bin/docker/attach_build
+++ b/bin/docker/attach_build
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET=build
-docker-compose run  --rm -e RAS_TARGET controller "/bin/bash"
+docker-compose run --rm --name controller -e RAS_TARGET controller "/bin/bash"

--- a/bin/docker/attach_build
+++ b/bin/docker/attach_build
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+export RAS_TARGET=build
+
+cd "$(dirname "$0")/.." || exit 1
+
+docker-compose run  --rm -e RAS_TARGET ras "/bin/bash"

--- a/bin/docker/attach_build
+++ b/bin/docker/attach_build
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET=build
-docker-compose run --rm --name controller -e RAS_TARGET controller "/bin/bash"
+docker-compose run --rm --name build -e RAS_TARGET ras "/bin/bash"

--- a/bin/docker/attach_controller
+++ b/bin/docker/attach_controller
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+export SSH_SOURCE=./fixtures/.ssh
+docker-compose run --rm --name controller -e SSH_SOURCE controller "/bin/bash"

--- a/bin/docker/attach_master
+++ b/bin/docker/attach_master
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+export RAS_TARGET=base
+docker-compose run --rm --name master -e RAS_TARGET master "/bin/bash"

--- a/bin/docker/attach_master
+++ b/bin/docker/attach_master
@@ -1,4 +1,4 @@
 #! /bin/sh
 
-export RAS_TARGET=base
-docker-compose run --rm --name master -e RAS_TARGET master "/bin/bash"
+export SSH_SOURCE=./fixtures/.ssh
+docker-compose run --rm --publish=2022:22 --name master -e SSH_SOURCE master

--- a/bin/docker/attach_prod
+++ b/bin/docker/attach_prod
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET=prod
-docker-compose run  --rm controller "/bin/bash"
+docker-compose run --rm --name controller -e RAS_TARGET controller "/bin/bash"

--- a/bin/docker/attach_prod
+++ b/bin/docker/attach_prod
@@ -1,7 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET=prod
-
-cd "$(dirname "$0")/.." || exit 1
-
-docker-compose run  --rm ras "/bin/bash"
+docker-compose run  --rm controller "/bin/bash"

--- a/bin/docker/attach_prod
+++ b/bin/docker/attach_prod
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+export RAS_TARGET=prod
+
+cd "$(dirname "$0")/.." || exit 1
+
+docker-compose run  --rm ras "/bin/bash"

--- a/bin/docker/build
+++ b/bin/docker/build
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+export RAS_TARGET="$@"
+docker-compose build ras

--- a/bin/docker/rebuild
+++ b/bin/docker/rebuild
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+export RAS_TARGET="$@"
+docker-compose build --no-cache ras

--- a/bin/docker/ref_arch_setup
+++ b/bin/docker/ref_arch_setup
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-docker-compose run --rm --name ref_arch_setup prod ref_arch_setup "$@"
+docker-compose run --rm --name ref_arch_setup ras ref_arch_setup "$@"

--- a/bin/docker/ref_arch_setup
+++ b/bin/docker/ref_arch_setup
@@ -1,4 +1,3 @@
 #! /bin/sh
 
-export RAS_TARGET=prod
-docker-compose run --rm --name controller -e RAS_TARGET controller ref_arch_setup "$@"
+docker-compose run --rm --name ref_arch_setup prod ref_arch_setup "$@"

--- a/bin/docker/ref_arch_setup
+++ b/bin/docker/ref_arch_setup
@@ -1,7 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET=prod
-
-cd "$(dirname "$0")/.." || exit 1
-
-docker-compose run  --rm -e RAS_TARGET ras ref_arch_setup "$@"
+docker-compose run  --rm -e RAS_TARGET controller ref_arch_setup "$@"

--- a/bin/docker/ref_arch_setup
+++ b/bin/docker/ref_arch_setup
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+export RAS_TARGET=prod
+
+cd "$(dirname "$0")/.." || exit 1
+
+docker-compose run  --rm -e RAS_TARGET ras ref_arch_setup "$@"

--- a/bin/docker/ref_arch_setup
+++ b/bin/docker/ref_arch_setup
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 export RAS_TARGET=prod
-docker-compose run  --rm -e RAS_TARGET controller ref_arch_setup "$@"
+docker-compose run --rm --name controller -e RAS_TARGET controller ref_arch_setup "$@"

--- a/bin/docker/setup_ssh
+++ b/bin/docker/setup_ssh
@@ -1,0 +1,11 @@
+#! /bin/sh
+
+if [ -e ./fixtures/.ssh/id_rsa ]
+then
+    echo "id_rsa already exists... exiting"
+else
+    echo "setting up ssh keys"
+    yes | ssh-keygen -q -t rsa -b 4096 -f ./fixtures/.ssh/id_rsa -N '' -C 'ras'
+    cat ./fixtures/.ssh/id_rsa.pub >> ./fixtures/.ssh/authorized_keys
+fi
+

--- a/bin/docker/ssh_entrypoint.sh
+++ b/bin/docker/ssh_entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# generate host keys if not present
+ssh-keygen -A
+
+# do not detach (-D), log to stderr (-e), passthrough other arguments
+exec /usr/sbin/sshd -D -e "$@"

--- a/bin/ras
+++ b/bin/ras
@@ -1,5 +1,0 @@
-#! /bin/sh
-
-cd "$(dirname "$0")/.." || exit 1
-
-docker-compose run  --rm ras ref_arch_setup "$@"

--- a/bin/ras
+++ b/bin/ras
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+cd "$(dirname "$0")/.." || exit 1
+
+docker-compose run  --rm ras ref_arch_setup "$@"

--- a/bin/ras_cmd
+++ b/bin/ras_cmd
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+cd "$(dirname "$0")/.." || exit 1
+
+docker-compose run  --rm ras "$@"

--- a/bin/ras_cmd
+++ b/bin/ras_cmd
@@ -1,5 +1,0 @@
-#! /bin/sh
-
-cd "$(dirname "$0")/.." || exit 1
-
-docker-compose run  --rm ras "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.6'
+
+services:
+  ras:
+    build: .
+    image: slv/ras
+    volumes:
+      - '~/.ssh:/root/.ssh'
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ version: '3.6'
 
 services:
   ras:
-    build: .
-    image: slv/ras
+    build:
+      context: .
+      target: ${RAS_TARGET}
+    image: slv/${RAS_TARGET}
     volumes:
       - '~/.ssh:/root/.ssh'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
 version: '3.6'
 
 services:
-  ras:
+  controller:
     build:
       context: .
       target: ${RAS_TARGET}
-    image: slv/${RAS_TARGET}
+    image: ras/${RAS_TARGET}
     volumes:
       - '~/.ssh:/root/.ssh'
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,11 @@ services:
     image: ras/${RAS_TARGET}
     volumes:
       - '~/.ssh:/root/.ssh'
+
+  master:
+    build:
+      context: .
+      target: base
+    image: ras/base
+    volumes:
+      - '~/.ssh:/root/.ssh'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,32 @@
 version: '3.6'
 
 services:
-  controller:
+
+  # single container for any build stage
+  ras:
     build:
       context: .
       target: ${RAS_TARGET}
     image: ras/${RAS_TARGET}
     volumes:
-      - '~/.ssh:/root/.ssh'
+      - "${SSH_SOURCE}:/root/.ssh"
 
+  # controller container for acceptance testing
+  controller:
+    build:
+      context: .
+      target: ${CONTROLLER_TARGET}
+    image: ras/${CONTROLLER_TARGET}
+    volumes:
+      - "${SSH_SOURCE}:/root/.ssh"
+
+  # master container for acceptance testing
   master:
     build:
       context: .
-      target: base
-    image: ras/base
+      target: ${MASTER_TARGET}
+    ports:
+          - "2022:22"
+    image: ras/${MASTER_TARGET}
     volumes:
-      - '~/.ssh:/root/.ssh'
+      - "${SSH_SOURCE}:/root/.ssh"

--- a/fixtures/.ssh/README.md
+++ b/fixtures/.ssh/README.md
@@ -1,0 +1,2 @@
+# Generating ssh keys for docker acceptance tests
+Run `./bin/docker/setup_ssh` from the ref_arch_setup directory

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -63,6 +63,8 @@ module RefArchSetup
       @bolt_options.each do |key, value|
         bolt_options_string << " --#{key} #{value}"
       end
+
+      bolt_options_string << " --no-host-key-check"
       bolt_options_string
     end
 

--- a/lib/ref_arch_setup/bolt_helper.rb
+++ b/lib/ref_arch_setup/bolt_helper.rb
@@ -6,7 +6,7 @@ module RefArchSetup
     BOLT_RUN_AS_USER = "root".freeze
 
     # the default options to specify when running bolt commands
-    BOLT_DEFAULT_OPTIONS = { "run-as" => BOLT_RUN_AS_USER }.freeze
+    BOLT_DEFAULT_OPTIONS = { "run-as" => BOLT_RUN_AS_USER, "no-host-key-check" => "" }.freeze
 
     @bolt_options = BOLT_DEFAULT_OPTIONS
 
@@ -61,10 +61,13 @@ module RefArchSetup
     def self.bolt_options_string
       bolt_options_string = ""
       @bolt_options.each do |key, value|
-        bolt_options_string << " --#{key} #{value}"
+        # options like no-host-key-check don't have a value
+        bolt_options_string << if value.empty?
+                                 " --#{key}"
+                               else
+                                 " --#{key} #{value}"
+                               end
       end
-
-      bolt_options_string << " --no-host-key-check"
       bolt_options_string
     end
 

--- a/spec/ref_arch_setup/bolt_helper_spec.rb
+++ b/spec/ref_arch_setup/bolt_helper_spec.rb
@@ -9,7 +9,7 @@ describe RefArchSetup::BoltHelper do
   let(:params)              { { "VAR1" => "1", "VAR2" => "2" } }
   let(:params_str)          { "VAR1=1 VAR2=2" }
   let(:bolt_default_opts)   { { "run-as" => "root" } }
-  let(:bolt_default_string) { "--run-as root" }
+  let(:bolt_default_string) { "--run-as root --no-host-key-check" }
   let(:bolt_user_opts)      { { "user" => "my_user", "password" => "my_password" } }
   let(:bolt_user_string)    { "--user my_user --password my_password" }
   let(:bolt_pkey_opts)      { { "private-key" => "private_key_path" } }


### PR DESCRIPTION
This update allows running RAS in a container. The `/bin/docker/ref_arch_setup` script can be used to initialize the container and run the `ref_arch_setup` command in the container via docker-compose. See the DOCKER.md file for more information and instructions for setting up the acceptance testing environment with 'controller' and 'master' containers.